### PR TITLE
IT-1116 Frontend: Config GUI does not work when base path is enabled

### DIFF
--- a/public/apps/configuration/backend_api/client.js
+++ b/public/apps/configuration/backend_api/client.js
@@ -3,6 +3,7 @@ import { merge } from 'lodash';
 import { uniq } from 'lodash';
 import { isPlainObject } from 'lodash';
 import { isEmpty } from 'lodash';
+import chrome from 'ui/chrome';
 
 /**
  * Backend API client service.
@@ -12,7 +13,9 @@ uiModules.get('apps/searchguard/configuration', [])
 
         const notify = createNotifier({});
 
-        const AUTH_BACKEND_API_ROOT = "/api/v1";
+        // Take the basePath configuration value into account
+        // @url https://www.elastic.co/guide/en/kibana/current/development-basepath.html
+        const AUTH_BACKEND_API_ROOT = chrome.addBasePath("/api/v1");
 
         this.testConnection =  () => {
 

--- a/public/apps/configuration/configuration.html
+++ b/public/apps/configuration/configuration.html
@@ -7,7 +7,8 @@
         <div class="row">
             <div class="col-xs-12" style="text-align: center;">
 
-                <img class="brand-image" src="/plugins/searchguard/assets/searchguard_logo.svg" width="250">
+                <img class="brand-image" kbn-src="/plugins/searchguard/assets/searchguard_logo.svg" width="250">
+
 
                 <h3 ng-if="accessState=='pending'" style="margin-top:0px;">Please wait ...</h3>
 


### PR DESCRIPTION
This fixes issues where Kibana is loaded using a basePath:
* Logo image on the home screen
* The AJAX calls get the basePath added to each request

This PR only concerns the frontend.