### PR TITLE
Fixed timeout error on login

### DIFF
--- a/lib/configuration/backend/searchguard_configuration_plugin.js
+++ b/lib/configuration/backend/searchguard_configuration_plugin.js
@@ -25,7 +25,7 @@ export default function (Client, config, components) {
 
     Client.prototype.searchguard.prototype.restapiinfo = ca({
         url: {
-            fmt: '_searchguard/api/permissionsinfo'
+            fmt: '/_searchguard/api/permissionsinfo'
         }
     });
 


### PR DESCRIPTION
### Kibana version:
6.1.1

### Elasticsearch version:
6.1.1

### Searchguard version:
6.1.1-20.1

### Own Home version:
6.1.1

### OS:
macOS High Sierra

### Browser version:
Chromium 54.0.2816.0 (64-bit)

----

Hi, 
in my kibana setup, I use searchguard combined with Own Home. Own Home is used as a proxy between searchguard and elasticsearch. 
After I updated my stack on 6.1.1 I get a timeout error after each login. I can fix this behaviour when I disable the Own Home plugin.
However, I would like to keep on using the Own Home plugin.

### The Problem
On login, searchguard sends a request `_searchguard/api/permissioninfo` to the ownhome proxy which should forward the request to elasticsearch. 
But the ownhome proxy throws a timeout error and elasticsearch never gets the request.  
When adding a `/` at the beginning of the request it works resulting in searchguard getting a response.

There are different kinds of requests in searchguard. With and without leading slashes. 
For example:
- [Request with slash](https://github.com/floragunncom/search-guard-kibana-plugin/blob/93e4547ec0c32395b04f726be4fb7f61d1ea7fc0/lib/configuration/backend/searchguard_configuration_plugin.js#L146)
- [Request without slash](https://github.com/floragunncom/search-guard-kibana-plugin/blob/93e4547ec0c32395b04f726be4fb7f61d1ea7fc0/lib/configuration/backend/searchguard_configuration_plugin.js#L28)

Is there any reason why the requests differ?