### PR TITLE
ITT-888 - Disable already mapped Search Guard roles in new role mappings

### DIFF
--- a/public/apps/configuration/sections/rolesmapping/views/edit.html
+++ b/public/apps/configuration/sections/rolesmapping/views/edit.html
@@ -16,12 +16,14 @@
                             <div>
                                 <div ng-show="isNew" style="margin-bottom:20px;">
                                     <h3 style="margin-top:0px;">{{service.newLabel}}:</h3>
-                                    <ui-select ng-if="rolesAutoComplete.length" ng-model="newResourceName"
+                                    <ui-select ng-if="rolesAutoComplete.length && loaded"
+                                               ng-model="newResourceName"
                                                on-select="onSelectedNewResourceName({item: $item})">
-                                        <ui-select-match placeholder="">
+                                        <ui-select-match placeholder="Search Guard Role">
                                             {{newResourceName.name}}
                                         </ui-select-match>
-                                        <ui-select-choices repeat="item in rolesAutoComplete | filter: $select.search track by $index">
+                                        <ui-select-choices repeat="item in rolesAutoComplete | filter: $select.search track by $index"
+                                                           ui-disable-choice="resourcenames.indexOf(item.name) > -1">
                                             <span ng-bind="item.name"></span>
                                         </ui-select-choices>
                                     </ui-select>


### PR DESCRIPTION
This PR disables already mapped Search Guard Roles when adding a new Role Mapping.