### PR TITLE
ITT-1098 - Prevent submitting an empty login form

### DIFF
--- a/public/apps/login/login.html
+++ b/public/apps/login/login.html
@@ -14,12 +14,12 @@
     <div class="input-group">
       <div class="input-group-addon"><i class="fa fa-user"></i></div>
       <input type="text" class="form-control kuiTextInput" id="sg.username" name="username" placeholder="Username"
-             ng-model="ui.credentials.username" ng-required="ui.errorMessage" autofocus/>
+             ng-model="ui.credentials.username" ng-required="ui.errorMessage || ! ui.credentials.username" autofocus/>
     </div>
     <div class="input-group">
       <div class="input-group-addon"><i class="fa fa-lock"></i></div>
       <input type="password" class="form-control kuiTextInput" id="sg.password" name="password" placeholder="Password"
-             ng-model="ui.credentials.password" ng-required="ui.errorMessage"/>
+             ng-model="ui.credentials.password" ng-required="ui.errorMessage || ! ui.credentials.password"/>
     </div>
     <button id="sg.login" type="submit" class="btn btn-default btn-login" style="{{ui.buttonstyle}}">Log in</button>
   </form>

--- a/public/apps/login/login.less
+++ b/public/apps/login/login.less
@@ -63,6 +63,15 @@
       margin-bottom: 1em;
     }
 
+    /**
+    * Override Kibana UI's styling on fields that have a required attribute.
+    * This prevents input fields to be marked as invalid on page load.
+    * As soon as the field has been edited, Angular's validation takes over.
+    */
+    .kuiTextInput:placeholder-shown:invalid {
+      border-color: #D9D9D9;
+    }
+
     .btn-login {
       width: 100%;
     }

--- a/public/directives/licensewarning.js
+++ b/public/directives/licensewarning.js
@@ -31,6 +31,7 @@ app.directive('sgLicenseWarning', function (systemstate) {
 
                 if (systemstate.isTrialLicense() && systemstate.licenseValid()) {
                     $scope.hint = "Your trial license expires in " + systemstate.expiresIn() + " days.";
+                    $scope.$apply('hint');
                 }
             });
 


### PR DESCRIPTION
This change prevents submitting the login form when one or both fields is/are empty.

I also changed the digest for the license hint - it wouldn't show on page load and instead show up in the next digestion cycle.