### PR TITLE
ITT-1140 - Add focus to dynamically created form fields

### DIFF
--- a/public/apps/configuration/directives/directives.js
+++ b/public/apps/configuration/directives/directives.js
@@ -8,5 +8,6 @@ import './permissions/permissions';
 import './fileupload/fileupload';
 import './header/header';
 import './errormessage/errormessage';
-//import './deletemodal/deletemodal';
 import './confirmationmodal/confirmationmodal';
+import './form_focusfield/form_focusaddedfield';
+import './form_focusfield/form_focusfield';

--- a/public/apps/configuration/directives/form_focusfield/form_focusaddedfield.js
+++ b/public/apps/configuration/directives/form_focusfield/form_focusaddedfield.js
@@ -12,13 +12,6 @@ app.directive('sgcFormFocusAddedField', function ($timeout) {
         link: function(scope, el) {
 
             /**
-             * The mutation is called when the container element is first
-             * rendered, which we will want to ignore
-             * @type {boolean}
-             */
-            let isRendered = true;
-
-            /**
              * The MutationObserver
              * @type {null|MutationObserver}
              */
@@ -35,10 +28,6 @@ app.directive('sgcFormFocusAddedField', function ($timeout) {
 
             // Callback function to execute when mutations are observed
             let observerCallback = function(mutationsList) {
-                if (! isRendered) {
-                    isRendered = true;
-                    return;
-                }
 
                 // We only want mutations with added nodes
                 let mutationsWithAdditions = mutationsList.filter((mutation) => {

--- a/public/apps/configuration/directives/form_focusfield/form_focusaddedfield.js
+++ b/public/apps/configuration/directives/form_focusfield/form_focusaddedfield.js
@@ -1,0 +1,85 @@
+import { uiModules } from 'ui/modules';
+
+const app = uiModules.get('apps/searchguard/configuration', []);
+
+/**
+ * Attaches a mutation observer and checks for
+ * dynamically added input type="text" elements
+ */
+app.directive('sgcFormFocusAddedField', function ($timeout) {
+    return {
+        restrict: 'A',
+        link: function(scope, el) {
+
+            /**
+             * The mutation is called when the container element is first
+             * rendered, which we will want to ignore
+             * @type {boolean}
+             */
+            let isRendered = true;
+
+            /**
+             * The MutationObserver
+             * @type {null|MutationObserver}
+             */
+            let observer = null;
+
+            /**
+             * Options for the MutationObserver
+             * @type {{childList: boolean, subtree: boolean}}
+             */
+            let config = {
+                childList: true,
+                subtree: true,
+            };
+
+            // Callback function to execute when mutations are observed
+            let observerCallback = function(mutationsList) {
+                if (! isRendered) {
+                    isRendered = true;
+                    return;
+                }
+
+                // We only want mutations with added nodes
+                let mutationsWithAdditions = mutationsList.filter((mutation) => {
+                    return (mutation.addedNodes.length);
+                });
+
+                if (mutationsWithAdditions.length === 0) {
+                    return;
+                }
+
+                // For now, only bother with the first mutation
+                let mutation = mutationsWithAdditions[0];
+
+                // Check the first added node and make sure it's an ELEMENT_NODE (nodeType === 1)
+                if (mutation.addedNodes[0].nodeType === 1) {
+
+                    let focusable = mutation.addedNodes[0].querySelector("input[type='text']");
+                    // Only focus on elements without a value for now
+                    if (focusable && focusable.value === '') {
+                        focusable.focus();
+                    }
+                }
+            };
+
+            if ('MutationObserver' in window) {
+                // Use a $timeout to avoid listening for mutations on the first render
+                $timeout(function() {
+                    observer = new MutationObserver(observerCallback);
+                    observer.observe(el[0], config);
+                });
+
+            }
+
+            /**
+             * Clean up
+             */
+            el.on('$destroy', function() {
+                if (observer !== null) {
+                    observer.disconnect();
+                }
+            });
+        }
+    };
+});

--- a/public/apps/configuration/directives/form_focusfield/form_focusfield.js
+++ b/public/apps/configuration/directives/form_focusfield/form_focusfield.js
@@ -1,0 +1,40 @@
+import { uiModules } from 'ui/modules';
+
+const app = uiModules.get('apps/searchguard/configuration', []);
+
+/**
+ * Adds focus to a single input field.
+ * Since we may use this in conjunction with UI-Select, we support
+ * adding the directive both directly to an input field, but also
+ * to a container, in which the element can be found.
+ */
+app.directive('sgcFormFocusField', function ($timeout) {
+    return {
+        restrict: 'A',
+        scope: {
+            focusWhen: '=',
+        },
+        link: function(scope, el) {
+            scope.$watch('focusWhen', function(current, previous) {
+                if (current === true && ! previous) {
+                    $timeout(function() {
+                        // We use several UI-Select instances, so in order to support those we
+                        // can also attach this directive to a parent container
+                        if (el[0].nodeName.toLowerCase() !== 'input') {
+                            let focusable = el[0].querySelector("input[type='text']");
+                            if (focusable) {
+                                focusable.focus();
+                            }
+                        } else {
+                            // Directive seems to be attached to an input element
+                            el[0].focus();
+                        }
+
+                    });
+
+                }
+            });
+
+        }
+    };
+});

--- a/public/apps/configuration/sections/actiongroups/views/edit.html
+++ b/public/apps/configuration/sections/actiongroups/views/edit.html
@@ -7,7 +7,7 @@
             <div class="row">
                 <div class="col-xs-12">
                     <div class="">
-                        <form name="objectForm" id="object-form" method="post" ng-submit="saveObject($event)" novalidate style="width:70%">
+                        <form sgc-form-focus-added-field name="objectForm" id="object-form" method="post" ng-submit="saveObject($event)" novalidate style="width:70%">
 
                             <sgc-error-message></sgc-error-message>
 

--- a/public/apps/configuration/sections/internalusers/views/edit.html
+++ b/public/apps/configuration/sections/internalusers/views/edit.html
@@ -40,7 +40,7 @@
                             </div>
 
                             <!-- Backend Roles -->
-                            <table class="kuiTable tableIndexGroups">
+                            <table class="kuiTable tableIndexGroups" sgc-form-focus-added-field>
                                 <thead>
                                     <tr>
                                         <th class="kuiTableHeaderCell tableHeaderCellIndexGroups">

--- a/public/apps/configuration/sections/roles/views/edit.html
+++ b/public/apps/configuration/sections/roles/views/edit.html
@@ -30,7 +30,7 @@
         <div class="container">
             <div class="row">
 
-                <form name="objectForm" id="object-form" method="post" ng-submit="saveObject($event)" novalidate style="width:70%">
+                <form sgc-form-focus-added-field name="objectForm" id="object-form" method="post" ng-submit="saveObject($event)" novalidate style="width:70%">
 
                     <sgc-error-message></sgc-error-message>
 
@@ -181,7 +181,7 @@
                                 <tbody>
                                 <tr class="kuiTableRow">
                                     <td class="kuiTableRowCell cellAlignTop" >
-                                        <fieldset class="marginbottom--small" id="object-form-index">
+                                        <fieldset class="marginbottom--small" id="object-form-index" sgc-form-focus-field focus-when="addingIndex === true">
                                             <ui-select ng-model="newIndexName"
                                                        on-select="onSelectedNewIndexName({item: $item})">
                                                 <ui-select-match placeholder="Index name">

--- a/public/apps/configuration/sections/rolesmapping/views/edit.html
+++ b/public/apps/configuration/sections/rolesmapping/views/edit.html
@@ -7,7 +7,7 @@
             <div class="row">
                 <div class="col-xs-12">
                     <div class="">
-                        <form name="objectForm" id="object-form" method="post" ng-submit="saveObject($event)" novalidate style="width:70%">
+                        <form sgc-form-focus-added-field name="objectForm" id="object-form" method="post" ng-submit="saveObject($event)" novalidate style="width:70%">
 
                             <sgc-error-message></sgc-error-message>
 


### PR DESCRIPTION
This PR adds two directives that will help setting focus on dynamically added or dynamically shown input fields. Probably not very important, but it may improve the UX a bit by reducing the number of clicks and tabs necessary.

form_focusaddedfield.js - This adds a native MutationObserver that checks for changes to the DOM. It is somewhat simplified to work on the use cases we currently have, but could be easily extended if needed. It works by checking for added nodes and then searches those nodes for an input field of type text. 

form_focusfield.js - This is a typical Angular directive that takes a parameter that, when it switches from false or undefined to true, sets the focus on an element.