### PR TITLE
ITT-1167 - Handle session timeouts

### DIFF
--- a/lib/hapi/auth.js
+++ b/lib/hapi/auth.js
@@ -60,7 +60,15 @@ export default function (pluginRoot, server, APP_ROOT, API_ROOT) {
                     if (request.url.path.indexOf(API_ROOT) === 0 || request.method !== 'get') {
                         return reply(Boom.forbidden(error));
                     } else {
+                        // If the session has expired, we may receive ajax requests that can't handle a 302 redirect.
+                        // In this case, we trigger a 401 and let the interceptor handle the redirect on the client side.
+                        if (request.headers.accept !== null && request.headers.accept.split(',').indexOf('application/json') > -1) {
+                            // The redirectTo property in the payload tells the interceptor to handle this error.
+                            return reply({message: 'Session expired', redirectTo: 'login'}).code(401);
+                        }
+
                         const nextUrl = encodeURIComponent(request.url.path);
+
                         return reply.redirect(`${basePath}${APP_ROOT}/login?nextUrl=${nextUrl}`);
                     }
                 }


### PR DESCRIPTION
Addresses #53 

This PR introduces an error interceptor that checks for 401 errors on any $http calls.
To avoid intercepting all errors, this interceptor checks for a "redirect" property on the response payload. If the property is present, we redirect to the login page, otherwise we just pass the error through. Hopefully, this avoids any unintended side effects, current or future.