### PR TITLE
ITT-1240 - Login page improvements for IE11

### DIFF
--- a/public/apps/login/login.html
+++ b/public/apps/login/login.html
@@ -14,14 +14,17 @@
     <div class="input-group">
       <div class="input-group-addon"><i class="fa fa-user"></i></div>
       <input type="text" class="form-control kuiTextInput" id="sg.username" name="username" placeholder="Username"
-             ng-model="ui.credentials.username" ng-required="ui.errorMessage || ! ui.credentials.username" autofocus/>
+             ng-class="{'has-error': ui.errorMessage}"
+             ng-model="ui.credentials.username" required autofocus/>
     </div>
     <div class="input-group">
       <div class="input-group-addon"><i class="fa fa-lock"></i></div>
       <input type="password" class="form-control kuiTextInput" id="sg.password" name="password" placeholder="Password"
-             ng-model="ui.credentials.password" ng-required="ui.errorMessage || ! ui.credentials.password"/>
+             ng-class="{'has-error': ui.errorMessage}"
+             ng-model="ui.credentials.password" required/>
     </div>
-    <button id="sg.login" type="submit" class="btn btn-default btn-login" style="{{ui.buttonstyle}}">Log in</button>
+
+    <button id="sg.login" type="submit" class="btn btn-default btn-login" ng-attr-style="{{ui.buttonstyle}}">Log in</button>
   </form>
 
   <p class="error-message" id="sg.errormessage" ng-if="ui.errorMessage">{{ ui.errorMessage }}</p>

--- a/public/apps/login/login.less
+++ b/public/apps/login/login.less
@@ -66,10 +66,18 @@
     /**
     * Override Kibana UI's styling on fields that have a required attribute.
     * This prevents input fields to be marked as invalid on page load.
-    * As soon as the field has been edited, Angular's validation takes over.
+    * As soon as the field has been edited or focused, Angular's validation takes over.
     */
-    .kuiTextInput:placeholder-shown:invalid {
+    .kuiTextInput:invalid:not(.ng-touched) {
       border-color: #D9D9D9;
+    }
+
+    /**
+    * If the user submitted the form and we received an error we explicitly set
+    * an error class, regardless of ng-touched or the :invalid attribute.
+    */
+    .kuiTextInput.has-error {
+      border-color: #A30000;
     }
 
     .btn-login {


### PR DESCRIPTION
Fixes #78.

The validation state on the login fields is now fixed by overriding Kibana's default style for invalid elements. Instead, we rely on Angular's validation styles.
I also added an explicit error state for the text fields if we receive an error after submitting the form.

The custom login button styles from the configuration file work now too.

Tested in IE11 on Win7. 