### PR TITLE
ITT-1289 - Don't save the role when clicking "cancel"

### DIFF
--- a/public/apps/configuration/sections/roles/views/edit.html
+++ b/public/apps/configuration/sections/roles/views/edit.html
@@ -472,7 +472,7 @@
 
                         <div class="formsubmit">
                             <button ng-if="!addingIndex" ng-disabled="!endpointAndMethodEnabled('ROLES', 'PUT') || resource.readonly"  class="kuiButton kuiButton--primary kuiButton--text" type="submit">Save Role Definition</button>
-                            <button ng-if="!addingIndex" class="kuiButton kuiButton--basic kuiButton--text" type="submit" ng-click="cancel()">Cancel</button>
+                            <button ng-if="!addingIndex" class="kuiButton kuiButton--basic kuiButton--text" type="button" ng-click="cancel()">Cancel</button>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
Fixes a possible bug that would save a role after the user clicks cancel in the role edit mode.