### PR TITLE
ITT-1088 Restrict basic auth for certain usernames

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export default function (kibana) {
                 basicauth: Joi.object().keys({
                     enabled: Joi.boolean().default(true),
                     unauthenticated_routes: Joi.array().default(["/api/status"]),
+                    forbiddenUserNames: Joi.array().default([]),
                     login: Joi.object().keys({
                         title: Joi.string().allow('').default('Please login to Kibana'),
                         subtitle: Joi.string().allow('').default('If you have forgotten your username or password, please ask your system administrator'),

--- a/lib/auth/routes.js
+++ b/lib/auth/routes.js
@@ -47,6 +47,16 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
         handler: {
             async: async (request, reply) => {
                 try {
+                    // In order to prevent direct access for certain usernames (e.g. service users like
+                    // kibanaserver, logstash etc.) we can add them to basicauth.forbiddenUserNames.
+                    // If the username in the payload matches an item in the forbidden array, we throw an AuthenticationError
+                    const basicAuthConfig = server.config().get('searchguard.basicauth');
+                    if (basicAuthConfig.forbiddenUserNames && basicAuthConfig.forbiddenUserNames.length) {
+                        if (request.payload && request.payload.username && basicAuthConfig.forbiddenUserNames.indexOf(request.payload.username) > -1) {
+                            throw new AuthenticationError('Invalid username or password');
+                        }
+                    }
+
                     let user = await server.plugins.searchguard.getSearchGuardBackend().authenticate(request.payload);
                     let session = {
                         username: user.username,


### PR DESCRIPTION
Adds a configuration option to kibana.yml that can be used to prevent access for certain usernames:
`searchguard.basicauth.forbiddenUserNames: ['username1', 'username2']`

If a forbidden username is detected while trying to login, an AuthenticationError is thrown.