### PR TITLE
ITT-675 - Hide navigation items before resolving, no configured role by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ export default function (kibana) {
                 enabled: Joi.boolean().default(true),
                 allow_client_certificates: Joi.boolean().default(false),
                 readonly_mode: Joi.object().keys({
-                    roles: Joi.array().default(["sg_kibana_readonly"]),
+                    roles: Joi.array().default([]),
                 }).default(),
                 cookie: Joi.object().keys({
                     secure: Joi.boolean().default(false),


### PR DESCRIPTION
As discussed, this PR introduces a couple of changes to the read only mode
1) Hides the navigation items before all information is resolved and then shows the appropriate links. The original PR did it the other way around.

2) No default role configured

3). If no readonly role is configured, the navigation items from 1) are never hidden