### PR TITLE
ITT-1533 - Handle casing when extracting the JWT url parameter

### DIFF
--- a/lib/auth/types/jwt/Jwt.js
+++ b/lib/auth/types/jwt/Jwt.js
@@ -46,15 +46,21 @@ export default class Jwt extends AuthType {
      */
     detectAuthHeaderCredentials(request, sessionCredentials = null) {
 
-        const urlparamname = this.config.get('searchguard.jwt.url_param');
-
         let authHeaderValue = null;
-        let jwtAuthParam = request.query[urlparamname];
+        const urlparamname = this.config.get('searchguard.jwt.url_param').toLowerCase();
+
+        // Go through all given query parameters and make them lowercase
+        // to avoid confusion when using uppercase or perhaps mixed caps
+        let lowerCaseQueryParameters = {};
+        Object.keys(request.query).forEach((query) => {
+            lowerCaseQueryParameters[query.toLowerCase()] = request.query[query];
+        });
+
+        let jwtAuthParam = lowerCaseQueryParameters[urlparamname] || null;
 
         // The token may be passed via a query parameter
         if (jwtAuthParam != null) {
             authHeaderValue = 'Bearer ' + jwtAuthParam;
-
         } else if (request.headers[this.authHeaderName]) {
             try {
                 authHeaderValue = request.headers[this.authHeaderName];


### PR DESCRIPTION
This PR removes the case sensitive constraint on the JWT url query parameter