### PR TITLE
ITT-1533 - Redirect to JWT login endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ export default function (kibana) {
                 }),
                 jwt: Joi.object().keys({
                     enabled: Joi.boolean().default(false),
+                    login_endpoint: Joi.string(),
                     url_param: Joi.string().default('authorization'),
                     header: Joi.string().default('Authorization')
                 }).default()

--- a/lib/auth/types/jwt/Jwt.js
+++ b/lib/auth/types/jwt/Jwt.js
@@ -17,6 +17,7 @@
 import AuthType from "../AuthType";
 import MissingTenantError from "../../errors/missing_tenant_error";
 import SessionExpiredError from "../../errors/session_expired_error";
+import {parse, format} from 'url';
 
 export default class Jwt extends AuthType {
 
@@ -116,12 +117,39 @@ export default class Jwt extends AuthType {
     }
 
     onUnAuthenticated(request, reply, error) {
+
         if (error instanceof MissingTenantError) {
             return reply.redirect(this.basePath + '/customerror?type=missingTenant');
-        } else if (error instanceof SessionExpiredError) {
-            return reply.redirect(this.basePath + '/customerror?type=sessionExpired');
         } else {
-            return reply.redirect(this.basePath + '/customerror?type=authError');
+            // The customer may use a login endpoint, to which we can redirect
+            // if the user isn't authenticated.
+            let loginEndpoint = this.config.get('searchguard.jwt.login_endpoint');
+            if (loginEndpoint) {
+                try {
+                    // Parse the login endpoint so that we can append our nextUrl
+                    // if the customer has defined query parameters in the endpoint
+                    let loginEndpointURLObject = parse(loginEndpoint, true);
+
+                    // Make sure we don't overwrite an existing "nextUrl" parameter,
+                    // just in case the customer is using that name for something else
+                    if (typeof loginEndpointURLObject.query['nextUrl'] === 'undefined') {
+                        const nextUrl = encodeURIComponent(request.url.path);
+                        // Delete the search parameter - otherwise format() will use its value instead of the .query property
+                        delete loginEndpointURLObject.search;
+                        loginEndpointURLObject.query['nextUrl'] = nextUrl;
+                    }
+                    // Format the parsed endpoint object into a URL and redirect
+                    return reply.redirect(format(loginEndpointURLObject));
+                } catch(error) {
+                    this.server.log(['error', 'searchguard'], 'An error occured while parsing the searchguard.jwt.login_endpoint value');
+                    return reply.redirect(this.basePath + '/customerror?type=authError');
+                }
+
+            } else if (error instanceof SessionExpiredError) {
+                return reply.redirect(this.basePath + '/customerror?type=sessionExpired');
+            } else {
+                return reply.redirect(this.basePath + '/customerror?type=authError');
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds the ability to define an external login_endpoint for the JWT AuthType.
If a login_endpoint is configured, the user is redirected to that url if
1) The session has expired, or
2) No valid JWT token found

A "nextUrl" query parameter is appended to the configured login_endpoint.