### PR TITLE
ITT-1534 - Fix for links that have a regex as one of the parameters

### DIFF
--- a/public/apps/configuration/sections/roles/controller.js
+++ b/public/apps/configuration/sections/roles/controller.js
@@ -41,6 +41,16 @@ app.controller('sgRolesController', function ($scope, $element, $route, createNo
     };
 
     /**
+     * An indexName can start with a / when using regular expressions.
+     * This leads to some issues with the Angular router if we don't encode them properly.
+     * @param indexName
+     * @returns {string}
+     */
+    $scope.encodeIndexName = function(indexName) {
+        return encodeURIComponent(indexName);
+    };
+
+    /**
      * Handle changed sorting conditions.
      * Since we only have one column sortable, changing the key doesn't really do anything.
      * Until we have more sortable columns, only the sort order is changed
@@ -514,7 +524,7 @@ app.controller('sgEditRolesController', function ($rootScope, $scope, $element, 
         $scope.resourcenames = Object.keys(response.data);
 
         var rolename = $routeParams.resourcename;
-        var indexname = $routeParams.indexname;
+        var indexname = decodeURIComponent($routeParams.indexname);
 
         if (rolename) {
             $scope.service.get(rolename)

--- a/public/apps/configuration/sections/roles/views/index.html
+++ b/public/apps/configuration/sections/roles/views/index.html
@@ -87,7 +87,7 @@
                                     <td class="kuiTableRowCell cellAlignTop">
                                         <div class="kuiTableRowCell__liner">
                                             <span ng-repeat="indexname in resources[rolename].indexnames.sort()">
-                                                <a title="{{indexname}}" class="kuiLink" ng-href="#/roles/edit/{{rolename}}/{{indexname | escape}}" >
+                                                <a title="{{indexname}}" class="kuiLink" ng-href="#/roles/edit/{{rolename}}/{{encodeIndexName(indexname) | escape}}" >
                                                     {{indexname}}
                                                 </a>
                                                 <br/>

--- a/public/chrome/readonly/enable_readonly.js
+++ b/public/chrome/readonly/enable_readonly.js
@@ -397,6 +397,7 @@ export function enableReadOnly($rootScope, $http, $window, $timeout, $q, $locati
         return;
     }
 
+
     if (!$injector.has('$route')) {
         return;
     }
@@ -429,7 +430,7 @@ export function enableReadOnly($rootScope, $http, $window, $timeout, $q, $locati
     // Set the path on the body element to allow us to hide
     // some of the edit- and write controls with CSS.
     $rootScope.$on('$routeChangeSuccess', function(event, next, current) {
-        if (next.$$route && next.$$route.originalPath) {
+        if (next && next.$$route && next.$$route.originalPath) {
             document.body.setAttribute('sg_path', next.$$route.originalPath.replace(':', '').split('/').join('_'));
 
             if (chrome.getInjected('multitenancy_enabled') && next.locals && next.locals.sg_resolvedInfo) {


### PR DESCRIPTION
This PR enables linking to indexnames with a regular expression.
Before, if the indexname started with a "/", Angular's routing would get confused and lead to an empty page.