### PR TITLE
ITT-1556 - Better check for request.headers.accept

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -180,7 +180,7 @@ export default class AuthType {
                         } else {
                             // If the session has expired, we may receive ajax requests that can't handle a 302 redirect.
                             // In this case, we trigger a 401 and let the interceptor handle the redirect on the client side.
-                            if (request.headers.accept !== null && request.headers.accept.split(',').indexOf('application/json') > -1) {
+                            if (request.headers && request.headers.accept && request.headers.accept.split(',').indexOf('application/json') > -1) {
                                 // The redirectTo property in the payload tells the interceptor to handle this error.
                                 return reply({message: 'Session expired', redirectTo: 'login'}).code(401);
                             }

--- a/lib/hapi/auth.js
+++ b/lib/hapi/auth.js
@@ -62,7 +62,7 @@ export default function (pluginRoot, server, APP_ROOT, API_ROOT) {
                     } else {
                         // If the session has expired, we may receive ajax requests that can't handle a 302 redirect.
                         // In this case, we trigger a 401 and let the interceptor handle the redirect on the client side.
-                        if (request.headers.accept !== null && request.headers.accept.split(',').indexOf('application/json') > -1) {
+                        if (request.headers && request.headers.accept && request.headers.accept.split(',').indexOf('application/json') > -1) {
                             // The redirectTo property in the payload tells the interceptor to handle this error.
                             return reply({message: 'Session expired', redirectTo: 'login'}).code(401);
                         }


### PR DESCRIPTION
Fixes an issue where the plugin would crash while checking for session timeout.
See here https://github.com/floragunncom/search-guard/issues/535 for more information.