### PR TITLE
ITT-1490 - Improve handling of non-existing indices or wildcards

### DIFF
--- a/public/apps/configuration/directives/autocomplete/uiselectcustom.js
+++ b/public/apps/configuration/directives/autocomplete/uiselectcustom.js
@@ -1,0 +1,23 @@
+import { uiModules } from 'ui/modules';
+const app = uiModules.get('apps/searchguard/configuration', []);
+
+/**
+ * This directive adds the ability to select an item in
+ * a dropdown list (ui-select) on blur, i.e. without
+ * explicitly clicking the selected item
+ *
+ * Credit: https://stackoverflow.com/a/31947492/847856
+ */
+app.directive('selectOnBlur', function() {
+    return {
+        require: 'uiSelect',
+        link: function(scope, element, attributes, uiSelectController) {
+            element.on('blur', 'input.ui-select-search', function(event) {
+                if(uiSelectController.open && (uiSelectController.activeIndex >= 0)){
+                    uiSelectController.select(uiSelectController.items[uiSelectController.activeIndex]);
+                }
+                event.target.value = '';
+            });
+        }
+    };
+})

--- a/public/apps/configuration/directives/directives.js
+++ b/public/apps/configuration/directives/directives.js
@@ -11,3 +11,4 @@ import './errormessage/errormessage';
 import './confirmationmodal/confirmationmodal';
 import './form_focusfield/form_focusaddedfield';
 import './form_focusfield/form_focusfield';
+import './autocomplete/uiselectcustom';

--- a/public/apps/configuration/sections/roles/views/edit.html
+++ b/public/apps/configuration/sections/roles/views/edit.html
@@ -183,6 +183,7 @@
                                     <td class="kuiTableRowCell cellAlignTop" >
                                         <fieldset class="marginbottom--small" id="object-form-index" sgc-form-focus-field focus-when="addingIndex === true">
                                             <ui-select ng-model="newIndexName"
+                                                       select-on-blur
                                                        on-select="onSelectedNewIndexName({item: $item})">
                                                 <ui-select-match placeholder="Index name">
                                                     {{newIndexName.name}}
@@ -199,6 +200,7 @@
                                     <td class="kuiTableRowCell cellAlignTop ">
                                         <fieldset class="marginbottom--small" id="object-form-actiongroups">
                                             <ui-select ng-model="newDocumentTypeName"
+                                                       select-on-blur
                                                        on-select="onSelectedNewDocumentTypeName({item: $item})"
                                                        reset-search-input="false">
                                                 <ui-select-match placeholder="Document Type name">


### PR DESCRIPTION
This PR adds a "select on blur" to the autocompletes when editing index permissions for roles, which means that you don't explicitly have to click the (custom) value anymore to really select it.

We could consider adding the same behaviour to the autocompletes that don't allow custom values too.