### PR TITLE
ITT-1608 - Roles: Index not preselected anymore on roles tab

### DIFF
--- a/public/apps/configuration/sections/roles/controller.js
+++ b/public/apps/configuration/sections/roles/controller.js
@@ -42,16 +42,6 @@ app.controller('sgRolesController', function ($scope, $element, $route, createNo
     };
 
     /**
-     * An indexName can start with a / when using regular expressions.
-     * This leads to some issues with the Angular router if we don't encode them properly.
-     * @param indexName
-     * @returns {string}
-     */
-    $scope.encodeIndexName = function(indexName) {
-        return encodeURIComponent(indexName);
-    };
-
-    /**
      * Handle changed sorting conditions.
      * Since we only have one column sortable, changing the key doesn't really do anything.
      * Until we have more sortable columns, only the sort order is changed
@@ -530,7 +520,7 @@ app.controller('sgEditRolesController', function ($rootScope, $scope, $element, 
         $scope.resourcenames = Object.keys(response.data);
 
         var rolename = $routeParams.resourcename;
-        var indexname = decodeURIComponent($routeParams.indexname);
+        var indexname = $routeParams.indexname;
 
         if (rolename) {
             $scope.service.get(rolename)

--- a/public/apps/configuration/sections/roles/index.js
+++ b/public/apps/configuration/sections/roles/index.js
@@ -23,6 +23,6 @@ uiRoutes
     .when('/roles/edit/:resourcename', {
       template: editRoleTemplate
     })
-    .when('/roles/edit/:resourcename/:indexname', {
+    .when('/roles/edit/:resourcename/:indexname*', {
         template: editRoleTemplate
     })

--- a/public/apps/configuration/sections/roles/views/index.html
+++ b/public/apps/configuration/sections/roles/views/index.html
@@ -87,7 +87,7 @@
                                     <td class="kuiTableRowCell cellAlignTop">
                                         <div class="kuiTableRowCell__liner">
                                             <span ng-repeat="indexname in resources[rolename].indexnames.sort()">
-                                                <a title="{{indexname}}" class="kuiLink" ng-href="#/roles/edit/{{rolename}}/{{encodeIndexName(indexname) | escape}}" >
+                                                <a title="{{indexname}}" class="kuiLink" ng-href="#/roles/edit/{{rolename}}/{{indexname | escape}}" >
                                                     {{indexname}}
                                                 </a>
                                                 <br/>


### PR DESCRIPTION
This PR fixes the case where no default index would be selected when editing a role's permissions.
Also, it simplifies they way we handle routes containing a regex, which was the cause for this bug.