### PR TITLE
ITT-1606 - Block users from logging in when they do not have at least one SG role

### DIFF
--- a/lib/auth/errors/missing_role_error.js
+++ b/lib/auth/errors/missing_role_error.js
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2018 floragunn GmbH
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+export default class MissingRoleError extends Error {
+
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+
+}

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -15,6 +15,7 @@
  */
 
 import AuthType from "../AuthType";
+import MissingRoleError from "../../errors/missing_role_error";
 
 export default class BasicAuth extends AuthType {
 
@@ -59,7 +60,11 @@ export default class BasicAuth extends AuthType {
         }
     }
 
-    onUnAuthenticated(request, reply) {
+    onUnAuthenticated(request, reply, error) {
+        if (error instanceof MissingRoleError) {
+            return reply.redirect(this.basePath + '/customerror?type=missingRole')
+        }
+
         const nextUrl = encodeURIComponent(request.url.path);
         return reply.redirect(`${this.basePath}${this.APP_ROOT}/login?nextUrl=${nextUrl}`);
     }

--- a/lib/auth/types/basicauth/routes.js
+++ b/lib/auth/types/basicauth/routes.js
@@ -18,6 +18,7 @@ import Boom from 'boom';
 import Joi from 'joi';
 import { isEmpty } from 'lodash';
 import MissingTenantError from "../../errors/missing_tenant_error";
+import MissingRoleError from "../../errors/missing_role_error";
 
 module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
 
@@ -92,7 +93,9 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
                     if (error instanceof AuthenticationError) {
                         return reply(Boom.unauthorized(error.message));
                     } else if (error instanceof MissingTenantError) {
-                        return reply(Boom.notFound('Missing Tenant'));
+                        return reply(Boom.notFound(error.message));
+                    } else if (error instanceof MissingRoleError) {
+                        return reply(Boom.notFound(error.message));
                     } else {
                         return reply(Boom.badImplementation(error.message));
                     }

--- a/lib/auth/types/jwt/Jwt.js
+++ b/lib/auth/types/jwt/Jwt.js
@@ -18,6 +18,7 @@ import AuthType from "../AuthType";
 import MissingTenantError from "../../errors/missing_tenant_error";
 import SessionExpiredError from "../../errors/session_expired_error";
 import {parse, format} from 'url';
+import MissingRoleError from "../../errors/missing_role_error";
 
 export default class Jwt extends AuthType {
 
@@ -126,6 +127,8 @@ export default class Jwt extends AuthType {
 
         if (error instanceof MissingTenantError) {
             return reply.redirect(this.basePath + '/customerror?type=missingTenant');
+        } else if (error instanceof MissingRoleError) {
+            return reply.redirect(this.basePath + '/customerror?type=missingRole');
         } else {
             // The customer may use a login endpoint, to which we can redirect
             // if the user isn't authenticated.

--- a/lib/auth/types/openid/OpenId.js
+++ b/lib/auth/types/openid/OpenId.js
@@ -17,6 +17,7 @@
 import AuthType from "../AuthType";
 import MissingTenantError from "../../errors/missing_tenant_error";
 import AuthenticationError from "../../errors/authentication_error";
+import MissingRoleError from "../../errors/missing_role_error";
 const Wreck = require('wreck');
 
 export default class OpenId extends AuthType {
@@ -81,6 +82,8 @@ export default class OpenId extends AuthType {
         // If we don't have any tenant we need to show the custom error page
         if (error instanceof MissingTenantError) {
             return reply.redirect(this.basePath + '/customerror?type=missingTenant')
+        } else if (error instanceof MissingRoleError) {
+            return reply.redirect(this.basePath + '/customerror?type=missingRole')
         } else if (error instanceof AuthenticationError) {
             return reply.redirect(this.basePath + '/customerror?type=authError')
         }

--- a/lib/auth/types/saml/Saml.js
+++ b/lib/auth/types/saml/Saml.js
@@ -17,6 +17,7 @@
 import AuthType from "../AuthType";
 import MissingTenantError from "../../errors/missing_tenant_error";
 import AuthenticationError from "../../errors/authentication_error";
+import MissingRoleError from "../../errors/missing_role_error";
 
 export default class Saml extends AuthType {
 
@@ -74,6 +75,8 @@ export default class Saml extends AuthType {
         // If we don't have any tenant we need to show the custom error page
         if (error instanceof MissingTenantError) {
             return reply.redirect(this.basePath + '/customerror?type=missingTenant')
+        } else if (error instanceof MissingRoleError) {
+            return reply.redirect(this.basePath + '/customerror?type=missingRole')
         } else if (error instanceof AuthenticationError) {
             return reply.redirect(this.basePath + '/customerror?type=samlAuthError')
         }

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -1,4 +1,5 @@
 import MissingTenantError from "../auth/errors/missing_tenant_error";
+import MissingRoleError from "../auth/errors/missing_role_error";
 
 var Hoek = require('hoek');
 var Joi = require('joi');
@@ -15,7 +16,8 @@ internals.config = Joi.object({
     authType: Joi.string().allow(null),
     authHeaderName: Joi.string(),
     authenticateFunction: Joi.func(),
-    validateAvailableTenants: Joi.boolean().default(true)
+    validateAvailableTenants: Joi.boolean().default(true),
+    validateAvailableRoles: Joi.boolean().default(true)
 }).required();
 
 
@@ -52,6 +54,11 @@ exports.register = async function (server, options, next) {
                         if (allTenants == null || Object.keys(allTenants).length === 0) {
                             throw new MissingTenantError('No tenant available for this user, please contact your system administrator.')
                         }
+                    }
+
+                    // Validate that the user has at least one valid role
+                    if (settings.validateAvailableRoles && (!authResponse.user.roles || authResponse.user.roles.length === 0)) {
+                        throw new MissingRoleError('No roles available for this user, please contact your system administrator.');
                     }
 
                     request.auth.session.set(authResponse.session);

--- a/public/apps/customerror/errormessage_types.js
+++ b/public/apps/customerror/errormessage_types.js
@@ -16,6 +16,14 @@ export const messageTypes = {
     },
 
     /**
+     * User does not have any valid role
+     */
+    missingRole: {
+        title: 'Missing Role',
+        subtitle: 'No roles available for this user, please contact your system administrator.',
+    },
+
+    /**
      * Session expired, most likely shown after an AJAX call from within Kibana
      */
     sessionExpired: {

--- a/public/apps/login/login_controller.js
+++ b/public/apps/login/login_controller.js
@@ -74,7 +74,8 @@ export default function LoginController(kbnUrl, $scope, $http, $window, systemst
                     if (error.status && error.status === 401) {
                         this.errorMessage = 'Invalid username or password, please try again';
                     } else if (error.status && error.status === 404) {
-                        this.errorMessage = 'No tenant available for this user, please contact your system administrator.';
+                        // This happens either when the user doesn't have any valid tenants or roles
+                        this.errorMessage = error.data.message;
                     } else {
                         this.errorMessage = 'An error occurred while checking your credentials, make sure you have an Elasticsearch cluster secured by Search Guard running.';
                     }


### PR DESCRIPTION
For every auth type, we know check if the logged in user has a valid role. If not, they will be redirected to the error page with a message saying they should contact the admin.
For basic auth, the error message is shown below the login form instead of a redirect.