### PR TITLE
ITT-329 - Kibana Anonymous access v2

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -31,7 +31,6 @@ export default class AuthType {
 
         this.basePath = this.config.get('server.basePath');
         this.unauthenticatedRoutes = this.config.get('searchguard.auth.unauthenticated_routes');
-        this.anonymousAuthEnabled = this.config.get('searchguard.auth.anonymous_auth_enabled');
 
         this.sessionTTL = this.config.get('searchguard.session.ttl');
         this.sessionKeepAlive = this.config.get('searchguard.session.keepalive');
@@ -175,24 +174,6 @@ export default class AuthType {
                                 return this.onUnAuthenticated(request, reply, authError);
                             }
                         }
-
-                        // This is a special case for when we have anonymous auth enabled AND are using basic auth
-                        if (this.anonymousAuthEnabled === true && this.type === 'basicauth') {
-                            try {
-                                let {session} = await request.auth.sgSessionStorage.authenticate({});
-                                session.isAnonymousAuth = true;
-
-                                // Returning the session equals setting the values with hapi-auth-cookie@set()
-                                return reply.continue({
-                                    // Watch out here - hapi-auth-cookie requires us to send back an object with credentials
-                                    // as a key. Otherwise other values than the credentials will be overwritten
-                                    credentials: session
-                                });
-                            } catch (authError) {
-                                return this.onUnAuthenticated(request, reply, authError);
-                            }
-                        }
-
 
                         if (request.url.path.indexOf(this.API_ROOT) === 0 || request.method !== 'get') {
                             return reply(Boom.forbidden(error));

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -33,9 +33,15 @@ export default class BasicAuth extends AuthType {
          * @type {string}
          */
         this.authHeaderName = 'authorization';
+
+        /**
+         * Allow anonymous access?
+         * @type {boolean}
+         */
+        this.anonymousAuthEnabled = this.config.get('searchguard.auth.anonymous_auth_enabled');
     }
 
-    async authenticate(credentials) {
+    async authenticate(credentials, options = {}) {
 
         // A login can happen via a POST request (login form) or when we have request headers with user credentials.
         // We also need to re-authenticate if the credentials (headers) don't match what's in the session.
@@ -44,7 +50,8 @@ export default class BasicAuth extends AuthType {
             let session = {
                 username: user.username,
                 credentials: credentials,
-                authType: this.type
+                authType: this.type,
+                isAnonymousAuth: (options && options.isAnonymousAuth === true) ? true : false
             };
 
             if(this.sessionTTL) {
@@ -66,6 +73,11 @@ export default class BasicAuth extends AuthType {
         }
 
         const nextUrl = encodeURIComponent(request.url.path);
+
+        if (this.anonymousAuthEnabled) {
+            return reply.redirect(`${this.basePath}${this.APP_ROOT}/auth/anonymous?nextUrl=${nextUrl}`);
+        }
+
         return reply.redirect(`${this.basePath}${this.APP_ROOT}/login?nextUrl=${nextUrl}`);
     }
 

--- a/lib/auth/types/basicauth/routes.js
+++ b/lib/auth/types/basicauth/routes.js
@@ -19,11 +19,13 @@ import Joi from 'joi';
 import { isEmpty } from 'lodash';
 import MissingTenantError from "../../errors/missing_tenant_error";
 import MissingRoleError from "../../errors/missing_role_error";
+import {parseNextUrl} from "../../parseNextUrl";
 
 module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
 
     const AuthenticationError = pluginRoot('lib/auth/errors/authentication_error');
     const loginApp = server.getHiddenUiAppById('searchguard-login');
+    const customErrorApp = server.getHiddenUiAppById('searchguard-customerror');
 
     /**
      * The login page.
@@ -119,6 +121,63 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
         handler: (request, reply) => {
             request.auth.sgSessionStorage.clear();
             reply({});
+        },
+        config: {
+            auth: false
+        }
+    });
+
+    server.route({
+        method: 'GET',
+        path: `${APP_ROOT}/auth/anonymous`,
+        handler: {
+            async: async (request, reply) => {
+
+                if (server.config().get('searchguard.auth.anonymous_auth_enabled')) {
+                    const basePath = server.config().get('server.basePath');
+                    try {
+                        let {session} = await request.auth.sgSessionStorage.authenticate({}, {isAnonymousAuth: true});
+
+                        let nextUrl = null;
+                        if (request.url && request.url.query && request.url.query.nextUrl) {
+                            nextUrl = parseNextUrl(request.url.query.nextUrl, basePath);
+                        }
+
+                        if (nextUrl) {
+                            nextUrl = parseNextUrl(nextUrl, basePath);
+                            return reply.redirect(nextUrl);
+                        }
+
+                        return reply.redirect(basePath + '/app/kibana');
+
+                    } catch (error) {
+
+                        if (error instanceof MissingRoleError) {
+                            return reply.redirect(basePath + '/customerror?type=missingRole');
+                        } else if (error instanceof MissingTenantError) {
+                            return reply.redirect(basePath + '/customerror?type=missingTenant');
+                        } else {
+                            return reply.redirect(basePath + '/customerror?type=anonymousAuthError');
+                        }
+                    }
+                } else {
+                    return reply.redirect(`${APP_ROOT}/login`);
+                }
+            }
+        },
+        config: {
+            auth: false
+        }
+    });
+
+    /**
+     * The error page.
+     */
+    server.route({
+        method: 'GET',
+        path:  `${APP_ROOT}/customerror`,
+        handler(request, reply) {
+            return reply.renderAppWithDefaultConfig(customErrorApp);
         },
         config: {
             auth: false

--- a/lib/session/sessionPlugin.js
+++ b/lib/session/sessionPlugin.js
@@ -33,14 +33,14 @@ exports.register = async function (server, options, next) {
 
             /**
              * Tries to authenticate a user. If multitenancy is enabled, we also try to validate that the
-             * user has at least one valid tenand
+             * user has at least one valid tenant
              * @param {object} credentials
              * @returns {Promise<*>}
              */
-            authenticate: async function(credentials) {
+            authenticate: async function(credentials, options = {}) {
                 try {
                     // authResponse is an object with .session and .user
-                    const authResponse = await settings.authenticateFunction(credentials);
+                    const authResponse = await settings.authenticateFunction(credentials, options);
 
                     // Make sure the user has a tenant that they can use
                     if(settings.validateAvailableTenants && server.config().get("searchguard.multitenancy.enabled") && ! server.config().get("searchguard.multitenancy.tenants.enable_global")) {

--- a/public/apps/customerror/errormessage_types.js
+++ b/public/apps/customerror/errormessage_types.js
@@ -52,5 +52,10 @@ export const messageTypes = {
     samlLogoutSuccess: {
         title: 'You have been logged out.',
         subtitle: ''
-    }
+    },
+
+    anonymousAuthError: {
+        title: 'Anonymous authentication error',
+        subtitle: 'Please make sure that anonymous auth is enabled in Search Guard.'
+    },
 };


### PR DESCRIPTION
This PR improves handling of the case where an explicitly logged in user's cookie expires. Previously, this would switch the user over to anonymous access. Now you're redirected to the login page instead.
If the user was anonymous, the cookie will be re-created.

This PR also adds an error message if the anonymous access isn't configured properly.