### PR TITLE
ITT-1642 - Redirect to an absolute loadbalancer url instead of a relative path

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ export default function (kibana) {
                     enabled: Joi.boolean().default(true),
                     unauthenticated_routes: Joi.array().default(["/api/status"]),
                     forbidden_usernames: Joi.array().default([]),
+                    loadbalancer_url: Joi.string().allow('', null).default(null),
                     login: Joi.object().keys({
                         title: Joi.string().allow('').default('Please login to Kibana'),
                         subtitle: Joi.string().allow('').default('If you have forgotten your username or password, please ask your system administrator'),

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -33,6 +33,12 @@ export default class BasicAuth extends AuthType {
          * @type {string}
          */
         this.authHeaderName = 'authorization';
+
+        /**
+         * Redirect to a loadbalancer url instead of a relative path when unauthenticated?
+         * @type {boolean}
+         */
+        this.loadBalancerURL = this.config.get('searchguard.basicauth.loadbalancer_url');
     }
 
     async authenticate(credentials) {
@@ -66,6 +72,11 @@ export default class BasicAuth extends AuthType {
         }
 
         const nextUrl = encodeURIComponent(request.url.path);
+
+        if (this.loadBalancerURL) {
+            return reply.redirect(`${this.loadBalancerURL}${this.basePath}${this.APP_ROOT}/login?nextUrl=${nextUrl}`);
+        }
+
         return reply.redirect(`${this.basePath}${this.APP_ROOT}/login?nextUrl=${nextUrl}`);
     }
 


### PR DESCRIPTION
This PR adds a config option for redirecting the user to an absolute URL instead of a relative path when the user is unauthenticated.
In other words, instead of redirecting to /login?nextUrl the user is redirected to https://www.myloadbalancer.com/login?nextUrl

I had some issues while cherry picking this into the feature branch. Please let me know if you run into issues while merging.