### PR TITLE
ITT-1685 - Better check for AJAX requests when session has expired

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -193,14 +193,11 @@ export default class AuthType {
                             }
                         }
 
-
-                        if (request.url.path.indexOf(this.API_ROOT) === 0 || request.method !== 'get') {
-                            return reply(Boom.forbidden(error));
-                        } else {
+                        if (request.headers) {
                             // If the session has expired, we may receive ajax requests that can't handle a 302 redirect.
                             // In this case, we trigger a 401 and let the interceptor handle the redirect on the client side.
-                            if (request.headers && request.headers.accept && request.headers.accept.split(',').indexOf('application/json') > -1) {
-                                // The redirectTo property in the payload tells the interceptor to handle this error.
+                            if ((request.headers.accept && request.headers.accept.split(',').indexOf('application/json') > -1)
+                                || (request.headers['content-type'] && request.headers['content-type'].indexOf('application/json') > -1)) {
                                 return reply({message: 'Session expired', redirectTo: 'login'}).code(401);
                             }
 


### PR DESCRIPTION
This PR addresses two things:
1. The Boom error we would get when running into an expired session on POST or api requests
2. It also checks the header "content-type" in order to detect an AJAX request better