### PR TITLE
ITT-1687 - Support IdP-initiated SSO

### DIFF
--- a/lib/auth/types/saml/routes.js
+++ b/lib/auth/types/saml/routes.js
@@ -74,7 +74,7 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
     });
 
     /**
-     * The page that the IdP redirects to after a successful login
+     * The page that the IdP redirects to after a successful SP-initiated login
      */
     server.route({
         method: 'POST',
@@ -85,11 +85,15 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
         handler: {
             async: async (request, reply) => {
 
-                let storedRequestInfo = request.auth.sgSessionStorage.getStorage('temp-saml');
+                let storedRequestInfo = request.auth.sgSessionStorage.getStorage('temp-saml', {});
                 request.auth.sgSessionStorage.clearStorage('temp-saml');
 
+                if (! storedRequestInfo.requestId) {
+                    return reply.redirect(basePath + '/customerror?type=samlAuthError');
+                }
+
                 try {
-                    let credentials = await server.plugins.searchguard.getSearchGuardBackend().authtoken(storedRequestInfo.requestId, request.payload.SAMLResponse);
+                    let credentials = await server.plugins.searchguard.getSearchGuardBackend().authtoken(storedRequestInfo.requestId || null, request.payload.SAMLResponse);
 
                     let {user} = await request.auth.sgSessionStorage.authenticate({
                         authHeaderValue: credentials.authorization
@@ -115,7 +119,40 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
                 }
             }
         }
+    });
 
+    /**
+     * The page that the IdP redirects to after a successful IdP-initiated login
+     */
+    server.route({
+        method: 'POST',
+        path: `${APP_ROOT}/searchguard/saml/acs/idpinitiated`,
+        config: {
+            auth: false
+        },
+        handler: {
+            async: async (request, reply) => {
+
+                try {
+                    let credentials = await server.plugins.searchguard.getSearchGuardBackend().authtoken(null, request.payload.SAMLResponse);
+
+                    let {user} = await request.auth.sgSessionStorage.authenticate({
+                        authHeaderValue: credentials.authorization
+                    });
+
+                    return reply.redirect(basePath + '/app/kibana');
+
+                } catch (error) {
+                    if (error instanceof AuthenticationError) {
+                        return reply.redirect(basePath + '/customerror?type=samlAuthError');
+                    } else if (error instanceof MissingTenantError) {
+                        return reply.redirect(basePath + '/customerror?type=missingTenant');
+                    } else {
+                        return reply.redirect(basePath + '/customerror?type=samlAuthError');
+                    }
+                }
+            }
+        }
     });
 
     /**


### PR DESCRIPTION
This PR adds an additional route for IdP-Initiated SSO.
The original route will now redirect to the error page if no RequestId is provided.