### PR TITLE
ITT-1660 - Handle redirect loop in the monitoring app

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,8 @@ export default function (kibana) {
                 'plugins/searchguard/chrome/accountinfo/enable_accountinfo',
                 'plugins/searchguard/chrome/logout_button',
                 'plugins/searchguard/chrome/configuration/enable_configuration',
-                'plugins/searchguard/services/access_control'
+                'plugins/searchguard/services/access_control',
+                'plugins/searchguard/customizations/enable_customizations.js'
             ],
             replaceInjectedVars: async function(originalInjectedVars, request, server) {
                 const authType = server.config().get('searchguard.auth.type');

--- a/public/customizations/enable_customizations.js
+++ b/public/customizations/enable_customizations.js
@@ -1,0 +1,72 @@
+/**
+ *    Copyright 2018 floragunn GmbH
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+
+import chrome from 'ui/chrome';
+import { uiModules } from 'ui/modules';
+
+
+const APP_ROOT = `${chrome.getBasePath()}`;
+let kibanaBaseUrl;
+
+/**
+ * Handles an infinite loop in the monitoring app
+ * when the user lacks the correct permissions.
+ * @param $injector
+ */
+function handleMonitoringLoop($injector) {
+
+    const currentApp = chrome.getApp();
+
+    if (currentApp.id !== 'monitoring') {
+        return;
+    }
+
+    if (!$injector.has('$route')) {
+        return;
+    }
+
+    const $window = $injector.get('$window');
+    const $route = $injector.get('$route');
+    if ($route.routes) {
+        for (let routeUrl in $route.routes) {
+            let route = $route.routes[routeUrl]
+            // Override the controller and the resolver for the access denied route
+            if (routeUrl.indexOf('/access-denied') > -1 && route.resolve && route.resolve.initialCheck) {
+                route.controller = function() {
+                    // The template's "Back to Kibana" button click handler
+                    this.goToKibana = () => {
+                        $window.location.href = APP_ROOT + kibanaBaseUrl;
+                    };
+                };
+                // Remove the original resolver
+                route.resolve = {};
+            }
+        }
+    }
+}
+
+export function enableCustomizations($injector) {
+    try {
+        kibanaBaseUrl = $injector.get('kbnBaseUrl');
+
+        handleMonitoringLoop($injector);
+    } catch (error) {
+        // Ignore
+    }
+}
+
+uiModules.get('searchguard').run(enableCustomizations);


### PR DESCRIPTION
This PR introduces a workaround for the redirect loop when the current user lacks permissions for monitoring. Fixes https://github.com/floragunncom/search-guard/issues/561.