### PR TITLE
extended logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ export default function (kibana) {
                     enabled: Joi.boolean().default(false),
                     show_roles: Joi.boolean().default(false),
                     enable_filter: Joi.boolean().default(false),
+                    debug: Joi.boolean().default(false),
                     tenants: Joi.object().keys({
                         enable_private: Joi.boolean().default(true),
                         enable_global: Joi.boolean().default(true),

--- a/lib/multitenancy/headers.js
+++ b/lib/multitenancy/headers.js
@@ -23,6 +23,7 @@ export default function (pluginRoot, server, APP_ROOT, API_ROOT) {
     const global_enabled = config.get("searchguard.multitenancy.tenants.enable_global");
     const private_enabled = config.get("searchguard.multitenancy.tenants.enable_private");
     const preferredTenants = config.get("searchguard.multitenancy.tenants.preferred");
+    const debugEnabled = config.get("searchguard.multitenancy.debug");
     const backend = server.plugins.searchguard.getSearchGuardBackend();
 
     server.ext('onPostAuth', async function (request, next) {
@@ -30,14 +31,28 @@ export default function (pluginRoot, server, APP_ROOT, API_ROOT) {
         // default is the tenant stored in the tenants cookie
         let selectedTenant = request.auth.sgSessionStorage.getStorage('tenant', {}).selected;
 
+        if (debugEnabled) {
+            request.log(['info', 'searchguard', 'tenant_storagecookie'], selectedTenant);
+        }
+
         // check for tenant information in HTTP header. E.g. when using the saved objects API
         if(request.headers.sgtenant || request.headers.sg_tenant) {
             selectedTenant = request.headers.sgtenant? request.headers.sgtenant : request.headers.sg_tenant;
+
+            if (debugEnabled) {
+                request.log(['info', 'searchguard', 'tenant_http_header'], selectedTenant);
+            }
+
         }
 
         // check for tenant information in GET parameter. E.g. when using a share link. Overwrites the HTTP header.
         if (request.query && (request.query.sg_tenant || request.query.sgtenant)) {
             selectedTenant = request.query.sg_tenant? request.query.sg_tenant : request.query.sgtenant;
+
+            if (debugEnabled) {
+                request.log(['info', 'searchguard', 'tenant_url_param'], selectedTenant);
+            }
+
         }
 
         // MT is only relevant for these paths
@@ -80,6 +95,10 @@ export default function (pluginRoot, server, APP_ROOT, API_ROOT) {
             } catch(error) {
                 // nothing
             }
+        }
+
+        if (debugEnabled) {
+            request.log(['info', 'searchguard', 'tenant_assigned'], selectedTenant);
         }
 
         if (selectedTenant != null) {

--- a/lib/multitenancy/routes.js
+++ b/lib/multitenancy/routes.js
@@ -17,17 +17,18 @@
 import Boom from 'boom';
 import Joi from 'joi';
 import indexTemplate from '../elasticsearch/setup_index_template';
-import { patchKibanaIndex } from '../../../../src/core_plugins/elasticsearch/lib/patch_kibana_index';
 
 module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
 
     const backend = server.plugins.searchguard.getSearchGuardBackend();
     const { setupIndexTemplate } = indexTemplate(this, server);
+    const debugEnabled = server.config().get("searchguard.multitenancy.debug");
 
     server.route({
         method: 'POST',
         path: `${API_ROOT}/multitenancy/tenant`,
         handler: (request, reply) => {
+
             var username = request.payload.username;
             var selectedTenant = request.payload.tenant;
             var prefs = backend.updateAndGetTenantPreferences(request, username, selectedTenant);
@@ -39,6 +40,10 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
                 selected: selectedTenant,
             });
 
+            if (debugEnabled) {
+                request.log(['info', 'searchguard', 'tenant_POST'], selectedTenant);
+            }
+
             return reply(request.payload.tenant).state('searchguard_preferences', prefs);
         }
     });
@@ -48,6 +53,11 @@ module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
         path: `${API_ROOT}/multitenancy/tenant`,
         handler: (request, reply) => {
             let selectedTenant = request.auth.sgSessionStorage.getStorage('tenant', {}).selected;
+
+            if (debugEnabled) {
+                request.log(['info', 'searchguard', 'tenant_GET'], selectedTenant);
+            }
+
             return reply(selectedTenant);
         }
     });


### PR DESCRIPTION
This PR introduces extended logging as described in ITT-1766. Since Kibana does not allow for a log4j style logging configuration where you have full control over what is being logged for what module, IMHO we need to introduce SG specific switches.