### PR TITLE
ITT-1775 - Ignore auth header when we have an existing session cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ export default function (kibana) {
                     enabled: Joi.boolean().default(true),
                     unauthenticated_routes: Joi.array().default(["/api/status"]),
                     forbidden_usernames: Joi.array().default([]),
+                    header_trumps_session: Joi.boolean().default(false),
                     alternative_login: Joi.object().keys({
                         headers: Joi.array().default([]),
                         show_for_parameter: Joi.string().allow('').default(''),

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -47,6 +47,43 @@ export default class BasicAuth extends AuthType {
         this.anonymousAuthEnabled = this.config.get('searchguard.auth.anonymous_auth_enabled');
     }
 
+    /**
+     * Checks if we have an authorization header.
+     *
+     * Pass the existing session credentials to compare with the authorization header.
+     *
+     * @param request
+     * @param sessionCredentials
+     * @returns {object|null} - credentials for the authentication
+     */
+    detectAuthHeaderCredentials(request, sessionCredentials = null) {
+
+        if (request.headers[this.authHeaderName]) {
+
+            const authHeaderValue = request.headers[this.authHeaderName];
+            const headerTrumpsSession = this.config.get('searchguard.basicauth.header_trumps_session');
+
+            // If we have sessionCredentials AND auth headers we need to check if they are the same.
+            if (sessionCredentials !== null && sessionCredentials.authHeaderValue === authHeaderValue) {
+                // The auth header credentials are the same as those in the session,
+                // no need to return new credentials so we're just nulling the token here
+                return null;
+            }
+
+            // We may have an auth header for a different user than the user saved in the session.
+            // To avoid confusion, we do NOT override the cookie user, unless that is explicitly configured.
+            if (sessionCredentials !== null && ! headerTrumpsSession) {
+                return null;
+            }
+
+            return {
+                authHeaderValue: authHeaderValue
+            }
+        }
+
+        return null;
+    }
+
     async authenticate(credentials, options = {}) {
 
         // A login can happen via a POST request (login form) or when we have request headers with user credentials.

--- a/lib/auth/types/basicauth/BasicAuth.js
+++ b/lib/auth/types/basicauth/BasicAuth.js
@@ -71,7 +71,7 @@ export default class BasicAuth extends AuthType {
             }
 
             // We may have an auth header for a different user than the user saved in the session.
-            // To avoid confusion, we do NOT override the cookie user, unless that is explicitly configured.
+            // To avoid confusion, we do NOT override the cookie user, unless explicitly configured to do so.
             if (sessionCredentials !== null && ! headerTrumpsSession) {
                 return null;
             }


### PR DESCRIPTION
This PR aims to remove the confusion caused when the browser send an authorization header, but we already have a logged in user. Now, if we already have a logged in user, we just ignore the header unless configured not to.
If we don't have a logged in user, we do use the authorization header as usual.