### PR TITLE
ITT-1776 - Earlier hook for assigning headers

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -259,6 +259,25 @@ export default class AuthType {
      *
      */
     assignAuthHeader() {
+        this.server.ext('onPreAuth', (request, next) => {
+            // Do not override any existing auth header
+            if (! request.headers[this.authHeaderName]) {
+                const sgAuth = request.state[this.config.get('searchguard.cookie.name')];
+                if (sgAuth && sgAuth.credentials) {
+                    const authHeader = {};
+                    authHeader[this.authHeaderName] = sgAuth.credentials.authHeaderValue;
+                    assign(request.headers, authHeader);
+                }
+            }
+
+            // Add tenant header too
+            const selectedTenant = request.auth.sgSessionStorage.getStorage('tenant', {}).selected;
+            if (selectedTenant != null) {
+                assign(request.headers, {'sgtenant' : selectedTenant});
+            }
+
+            return next.continue();
+        });
         this.server.ext('onPostAuth', (request, next) => {
             if (request.auth.sgSessionStorage.isAuthenticated()) {
                 const session = request.auth.sgSessionStorage.getSessionCredentials();


### PR DESCRIPTION
This PR adds a hook that assigns necessary headers earlier in the hapi request flow.