### PR TITLE
SGCS-167: TLS options for OpenID IdP

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,9 @@ export default function (kibana) {
                     client_secret: Joi.string().allow('').default(''),
                     scope: Joi.string().default('openid profile email address phone'),
                     base_redirect_url: Joi.string().allow('').default(''),
-                    logout_url: Joi.string().allow('').default('')
+                    logout_url: Joi.string().allow('').default(''),
+                    root_ca: Joi.string().allow('').default(''),
+                    verify_hostnames: Joi.boolean().default(true)
                 }).default().when('auth.type', {
                     is: 'openid',
                     then: Joi.object({

--- a/lib/auth/types/openid/OpenId.js
+++ b/lib/auth/types/openid/OpenId.js
@@ -19,6 +19,8 @@ import MissingTenantError from "../../errors/missing_tenant_error";
 import AuthenticationError from "../../errors/authentication_error";
 import MissingRoleError from "../../errors/missing_role_error";
 const Wreck = require('wreck');
+const https = require('https');
+const fs = require('fs');
 
 export default class OpenId extends AuthType {
 
@@ -31,6 +33,22 @@ export default class OpenId extends AuthType {
          * @type {string}
          */
         this.type = 'openid';
+
+        // support for self signed certificates: root ca and verify hostname
+        const options = {};
+
+        if (this.config.get('searchguard.openid.root_ca')) {
+            options.ca = [ fs.readFileSync(this.config.get('searchguard.openid.root_ca')) ]
+        }
+
+        if (this.config.get('searchguard.openid.verify_hostnames') == false) {
+            // do not check identity
+            options.checkServerIdentity = function(host, cert) {}
+        }
+
+        if (options.ca || options.checkServerIdentity) {
+            Wreck.agents.https = new https.Agent(options);
+        }
 
         try {
             this.authHeaderName = this.config.get('searchguard.openid.header').toLowerCase();
@@ -97,7 +115,7 @@ export default class OpenId extends AuthType {
             if (err ||
                 response.statusCode < 200 ||
                 response.statusCode > 299) {
-
+                this.server.log(["error", "openid"], err);
                 throw new Error('Failed when trying to obtain the endpoints from your IdP');
             }
 

--- a/lib/multitenancy/routes.js
+++ b/lib/multitenancy/routes.js
@@ -17,7 +17,6 @@
 import Boom from 'boom';
 import Joi from 'joi';
 import indexTemplate from '../elasticsearch/setup_index_template';
-import { patchKibanaIndex } from '../../../../src/core_plugins/elasticsearch/lib/patch_kibana_index';
 
 module.exports = function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT) {
 


### PR DESCRIPTION
This PR makes it possible to define a root CA and to disable hostname verification for Wreck's OpenID connections. Required if customers use self-signed certificates.