### PR TITLE
feature/proxycache

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ export default function (kibana) {
                     name: Joi.string().default('searchguard_authentication'),
                     password: Joi.string().min(32).default('searchguard_cookie_default_password'),
                     ttl: Joi.number().integer().min(0).default(60 * 60 * 1000),
+                    domain: Joi.string()
                 }).default(),
                 session: Joi.object().keys({
                     ttl: Joi.number().integer().min(0).default(60 * 60 * 1000),
@@ -96,12 +97,15 @@ export default function (kibana) {
                 proxycache: Joi.object().keys({
                     user_header: Joi.string(),
                     roles_header: Joi.string(),
+                    proxy_header: Joi.string().default('x-forwarded-for'),
+                    proxy_header_ip: Joi.string(),
                     login_endpoint: Joi.string().allow('', null).default(null),
                 }).default().when('auth.type', {
                     is: 'proxycache',
                     then: Joi.object({
                         user_header: Joi.required(),
-                        roles_header: Joi.required()
+                        roles_header: Joi.required(),
+                        proxy_header_ip: Joi.required()
                     })
                 }),
                 jwt: Joi.object().keys({
@@ -298,13 +302,19 @@ export default function (kibana) {
             }
 
             // Set up the storage cookie
-            server.state('searchguard_storage', {
+            let storageCookieConf = {
                 path: '/',
                 ttl: null, // Cookie deleted when the browser is closed
                 password: config.get('searchguard.cookie.password'),
                 encoding: 'iron',
                 isSecure: config.get('searchguard.cookie.secure'),
-            });
+            };
+
+            if (config.get('searchguard.cookie.domain')) {
+                storageCookieConf["domain"] = config.get('searchguard.cookie.domain');
+            }
+
+            server.state('searchguard_storage', storageCookieConf);
 
             if (authType && authType !== '' && ['basicauth', 'jwt', 'openid', 'saml', 'proxycache'].indexOf(authType) > -1) {
 
@@ -383,7 +393,7 @@ export default function (kibana) {
                 require('./lib/multitenancy/routes')(pluginRoot, server, this, APP_ROOT, API_ROOT);
                 require('./lib/multitenancy/headers')(pluginRoot, server, this, APP_ROOT, API_ROOT);
 
-                server.state('searchguard_preferences', {
+                let preferenceCookieConf = {
                     ttl: 2217100485000,
                     path: '/',
                     isSecure: false,
@@ -392,7 +402,13 @@ export default function (kibana) {
                     strictHeader: true, // don't allow violations of RFC 6265
                     encoding: 'iron',
                     password: config.get("searchguard.cookie.password")
-                });
+                };
+
+                if (config.get('searchguard.cookie.domain')) {
+                    preferenceCookieConf["domain"] = config.get('searchguard.cookie.domain');
+                }
+
+                server.state('searchguard_preferences', preferenceCookieConf);
 
                 this.status.yellow("Search Guard multitenancy registered. This is an Enterprise feature.");
             } else {

--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -267,7 +267,7 @@ export default class AuthType {
                 try {
                     let authHeader = this.getAuthHeader(session);
                     if (authHeader !== false) {
-                        this.addProxyAuthHeaders(request,authHeader);
+                        this.addAdditionalAuthHeaders(request, authHeader);
                         assign(request.headers, authHeader);
                         return next.continue();
                     }
@@ -283,19 +283,13 @@ export default class AuthType {
         });
     }
 
-    addProxyAuthHeaders(request, authHeader) {
-        // for proxy cache mode, make it possible to assign the proxy ip,
-        // usually as x-forwarded-for header. Only if no headers are already present
-        if (this.config.get('searchguard.auth.type') == "proxycache") {
-            let existingProxyHeaders = request.headers[this.config.get('searchguard.proxycache.proxy_header')];
-            // do not overwrite existing headers from existing proxy
-            if (existingProxyHeaders) {
-                return;
-            }
-            let remoteIP = request.info.remoteAddress;
-            let proxyIP = this.config.get('searchguard.proxycache.proxy_header_ip');
-            authHeader[this.config.get('searchguard.proxycache.proxy_header')] = remoteIP+","+proxyIP
-        }
+    /**
+     * Method for adding additional auth type specific authentication headers.
+     * Override this in the auth type for type specific headers.
+     * @param request
+     * @param authHeader
+     */
+    addAdditionalAuthHeaders(request, authHeader) {
 
     }
 }

--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -267,11 +267,7 @@ export default class AuthType {
                 try {
                     let authHeader = this.getAuthHeader(session);
                     if (authHeader !== false) {
-                        // for proxy cache mode, make it possible to assign the proxy ip,
-                        // usually as x-forwarded-for header
-                        if (this.config.get('searchguard.proxycache.proxy_header')) {
-                            authHeader[this.config.get('searchguard.proxycache.proxy_header')] = this.config.get('searchguard.proxycache.proxy_header_ip');
-                        }
+                        this.addProxyAuthHeaders(request,authHeader);
                         assign(request.headers, authHeader);
                         return next.continue();
                     }
@@ -285,5 +281,21 @@ export default class AuthType {
 
             return next.continue();
         });
+    }
+
+    addProxyAuthHeaders(request, authHeader) {
+        // for proxy cache mode, make it possible to assign the proxy ip,
+        // usually as x-forwarded-for header. Only if no headers are already present
+        if (this.config.get('searchguard.auth.type') == "proxycache") {
+            let existingProxyHeaders = request.headers[this.config.get('searchguard.proxycache.proxy_header')];
+            // do not overwrite existing headers from existing proxy
+            if (existingProxyHeaders) {
+                return;
+            }
+            let remoteIP = request.info.remoteAddress;
+            let proxyIP = this.config.get('searchguard.proxycache.proxy_header_ip');
+            authHeader[this.config.get('searchguard.proxycache.proxy_header')] = remoteIP+","+proxyIP
+        }
+
     }
 }

--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -85,7 +85,9 @@ export default class AuthType {
             clearInvalid: true,
             ttl: this.config.get('searchguard.cookie.ttl')
         };
-
+        if (this.config.get('searchguard.cookie.domain')) {
+            cookieConfig["domain"] = this.config.get('searchguard.cookie.domain');
+        }
         return cookieConfig;
     }
 
@@ -265,6 +267,11 @@ export default class AuthType {
                 try {
                     let authHeader = this.getAuthHeader(session);
                     if (authHeader !== false) {
+                        // for proxy cache mode, make it possible to assign the proxy ip,
+                        // usually as x-forwarded-for header
+                        if (this.config.get('searchguard.proxycache.proxy_header')) {
+                            authHeader[this.config.get('searchguard.proxycache.proxy_header')] = this.config.get('searchguard.proxycache.proxy_header_ip');
+                        }
                         assign(request.headers, authHeader);
                         return next.continue();
                     }

--- a/lib/auth/types/proxycache/ProxyCache.js
+++ b/lib/auth/types/proxycache/ProxyCache.js
@@ -158,4 +158,18 @@ export default class ProxyCache extends AuthType {
         require('./routes')(this.pluginRoot, this.server, this.kbnServer, this.APP_ROOT, this.API_ROOT);
     }
 
+    addAdditionalAuthHeaders(request, authHeader) {
+        // for proxy cache mode, make it possible to assign the proxy ip,
+        // usually as x-forwarded-for header. Only if no headers are already present
+        let existingProxyHeaders = request.headers[this.config.get('searchguard.proxycache.proxy_header')];
+        // do not overwrite existing headers from existing proxy
+        if (existingProxyHeaders) {
+            return;
+        }
+
+        let remoteIP = request.info.remoteAddress;
+        let proxyIP = this.config.get('searchguard.proxycache.proxy_header_ip');
+        authHeader[this.config.get('searchguard.proxycache.proxy_header')] = remoteIP+","+proxyIP
+    }
+
 }


### PR DESCRIPTION
This PR for proxycache authentication mode adds the capability to set the domain of the Search Guard cookies so customers can share them between subdomains. It also makes it possible to add the Kibana IP as x-forwarded-for header, so the XFFResolver in ES/SG is able to pick up the user and role headers added from the cached values.