### PR TITLE
ITT-1769 - Avoid double encoding for next url

### DIFF
--- a/lib/auth/types/proxycache/parse_login_endpoint.js
+++ b/lib/auth/types/proxycache/parse_login_endpoint.js
@@ -30,7 +30,7 @@ export function parseLoginEndpoint(loginEndpoint, request = null) {
     // Make sure we don't overwrite an existing "nextUrl" parameter,
     // just in case the customer is using that name for something else
     if (typeof loginEndpointURLObject.query['nextUrl'] === 'undefined' && request) {
-        const nextUrl = encodeURIComponent(request.url.path);
+        const nextUrl = request.url.path;
         // Delete the search parameter - otherwise format() will use its value instead of the .query property
         delete loginEndpointURLObject.search;
         loginEndpointURLObject.query['nextUrl'] = nextUrl;


### PR DESCRIPTION
Removes the (double) encoding for the login_endpoint.
The url will still be encoded, but only once.