### PR TITLE
SGCS-193 avoid double slashes in nextUrl

### DIFF
--- a/lib/auth/parseNextUrl.js
+++ b/lib/auth/parseNextUrl.js
@@ -33,6 +33,9 @@ export function parseNextUrl(nextUrl, basePath) {
     
     // We always need the base path
     if (!String(pathname).startsWith(basePath)) {
+        if (nextUrl && nextUrl != null && nextUrl.startsWith("/")) {
+            nextUrl = nextUrl.substring(1);
+        }
         return `${basePath}/${nextUrl}`;
     }
 


### PR DESCRIPTION
This PR handles the situation where we would add two forward slashes when redirecting the user after a successful login. In most cases, two slashes should not create any issues, but at least one customers experienced problems when using a proxy in front of Kibana.