### PR TITLE
ITT-1894 - Use same isSameSite value as before 6.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ export default function (kibana) {
                     name: Joi.string().default('searchguard_authentication'),
                     password: Joi.string().min(32).default('searchguard_cookie_default_password'),
                     ttl: Joi.number().integer().min(0).default(60 * 60 * 1000),
-                    domain: Joi.string()
+                    domain: Joi.string(),
+                    isSameSite: Joi.valid('Strict', 'Lax').allow(false).default(false),
                 }).default(),
                 session: Joi.object().keys({
                     ttl: Joi.number().integer().min(0).default(60 * 60 * 1000),
@@ -310,6 +311,7 @@ export default function (kibana) {
                 password: config.get('searchguard.cookie.password'),
                 encoding: 'iron',
                 isSecure: config.get('searchguard.cookie.secure'),
+                isSameSite: config.get('searchguard.cookie.isSameSite')
             };
 
             if (config.get('searchguard.cookie.domain')) {
@@ -407,7 +409,8 @@ export default function (kibana) {
                     clearInvalid: true, // remove invalid cookies
                     strictHeader: true, // don't allow violations of RFC 6265
                     encoding: 'iron',
-                    password: config.get("searchguard.cookie.password")
+                    password: config.get("searchguard.cookie.password"),
+                    isSameSite: config.get('searchguard.cookie.isSameSite')
                 };
 
                 if (config.get('searchguard.cookie.domain')) {

--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -94,7 +94,8 @@ export default class AuthType {
             isSecure: this.config.get('searchguard.cookie.secure'),
             validateFunc: this.sessionValidator(this.server),
             clearInvalid: true,
-            ttl: this.config.get('searchguard.cookie.ttl')
+            ttl: this.config.get('searchguard.cookie.ttl'),
+            isSameSite: this.config.get('searchguard.cookie.isSameSite')
         };
 
         if (this.config.get('searchguard.cookie.domain')) {


### PR DESCRIPTION
This PR fixes a regression caused by upgrading the hapi-auth-cookie.