### PR TITLE
ITT-1896 - Fixed an issue where the navlink icons would disappear in non-Kibana apps

### DIFF
--- a/public/chrome/configuration/enable_configuration.js
+++ b/public/chrome/configuration/enable_configuration.js
@@ -17,6 +17,9 @@
 
 import chrome from 'ui/chrome';
 import { uiModules } from 'ui/modules';
+// This fixes an issue where the app icons would disappear while having a non-Kibana app open.
+// Should be fixed starting from Kibana 6.6.2
+import 'ui/autoload/modules';
 import { FeatureCatalogueRegistryProvider, FeatureCatalogueCategory } from 'ui/registry/feature_catalogue';
 require ('../../apps/configuration/systemstate/systemstate');
 


### PR DESCRIPTION
This PR fixes the missing navlink icons when having one of SearchGuards app open.
Only needed for 6.6, and the issue has supposedly been fixed in Kibana 6.6.2.