### PR TITLE
ITT-1903 - Improved cookie validation

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -280,18 +280,33 @@ export default class AuthType {
      * Add credential headers to the passed request.
      * @param request
      */
-    assignAuthHeader(request) {
+    async assignAuthHeader(request) {
 
         if (! request.headers[this.authHeaderName]) {
 
-            const session = request.state[this.config.get('searchguard.cookie.name')];
+
+            let session = request.state[this.config.get('searchguard.cookie.name')];
+
+            if (session) {
+                const sessionValidator = this.sessionValidator();
+                try {
+                    const sessionValidationResult = await sessionValidator(request, session);
+                    if (sessionValidationResult.valid) {
+                        session = sessionValidationResult.credentials;
+                    } else {
+                        session = false;
+                    }
+                } catch(error) {
+                    this.server.log(['searchguard', 'error'], `An error occurred while computing auth headers, clearing session: ${error}`);
+                }
+            }
+
             if (session && session.credentials) {
                 try {
                     let authHeader = this.getAuthHeader(session);
                     if (authHeader !== false) {
                         this.addAdditionalAuthHeaders(request, authHeader);
                         assign(request.headers, authHeader);
-                        this.addAdditionalAuthHeaders(request, authHeader);
                     }
                 } catch (error) {
                     this.server.log(['searchguard', 'error'], `An error occurred while computing auth headers, clearing session: ${error}`);

--- a/lib/multitenancy/headers.js
+++ b/lib/multitenancy/headers.js
@@ -67,7 +67,7 @@ export default function (pluginRoot, server, kbnServer, APP_ROOT, API_ROOT, auth
 
         try {
             if (authClass) {
-                authClass.assignAuthHeader(request);
+                await authClass.assignAuthHeader(request);
             }
 
             response = await request.auth.sgSessionStorage.getAuthInfo(request.headers);


### PR DESCRIPTION
This PR fixes a merge error for the additionalAuthHeaders and also validates the cookie in onPreAuth.
This needs to be merged into 6.5 as well and requires minor changes because of the different Hapi versions.