### PR TITLE
ITT-1998 - Removed unused package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "bell": "9.4.0",
     "hapi-auth-cookie": "^9.1.0",
     "joi": "10.6.0",
-    "js-yaml": "^3.7.0",
     "requirefrom": "^0.2.0",
     "wreck": "14.x.x"
   },


### PR DESCRIPTION
This PR removes the js-yaml package, which wasn't really used anywhere.