### PR TITLE
make logout url configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ export default function (kibana) {
                     type: Joi.string().valid(['', 'basicauth', 'jwt', 'openid', 'saml', 'proxy', 'kerberos', 'proxycache']).default(''),
                     anonymous_auth_enabled: Joi.boolean().default(false),
                     unauthenticated_routes: Joi.array().default(["/api/status"]),
+                    logout_url: Joi.string().allow('').default(''),
                 }).default(),
                 basicauth: Joi.object().keys({
                     enabled: Joi.boolean().default(true),

--- a/public/services/access_control.js
+++ b/public/services/access_control.js
@@ -26,6 +26,7 @@ uiModules
 
   const authConfig = chrome.getInjected('auth');
   const authType = authConfig.type || null;
+  const logoutUrl = authConfig.logout_url || null;
 
   class SearchGuardControlService {
 
@@ -42,7 +43,11 @@ uiModules
                     $window.location.href = `${APP_ROOT}/customerror`;
                 }
             } else {
-                $window.location.href = `${APP_ROOT}/login?type=${authType || ''}Logout`;
+                if (logoutUrl && logoutUrl.length > 0) {
+                    $window.location.href = logoutUrl;
+                } else {
+                    $window.location.href = `${APP_ROOT}/login?type=${authType || ''}Logout`;
+                }
             }
           },
           (error) =>


### PR DESCRIPTION
This PR adds a configurable logout URL for auth types that do not specify their own (Basic Auth, JWT)