### PR TITLE
ITT-2048 - Support special characters in tenant names

### DIFF
--- a/lib/auth/parseNextUrl.js
+++ b/lib/auth/parseNextUrl.js
@@ -25,12 +25,12 @@ import { parse } from 'url';
 export function parseNextUrl(nextUrl, basePath) {
 
     // check forgery of protocol, hostname, port, pathname
-    const { protocol, hostname, port, pathname, hash } = parse(decodeURIComponent(nextUrl), true, true);
+    const { protocol, hostname, port, pathname, hash } = parse(nextUrl, true, true);
     // If we have a relative protocol, hostname is reported as an empty string, so we need to make sure it is null
     if (protocol !== null || hostname !== null || port !== null) {
         return `${basePath}/`;
     }
-    
+
     // We always need the base path
     if (!String(pathname).startsWith(basePath)) {
         if (nextUrl && nextUrl != null && nextUrl.startsWith("/")) {
@@ -40,6 +40,6 @@ export function parseNextUrl(nextUrl, basePath) {
     }
 
     // All valid
-    return nextUrl
+    return nextUrl;
 
 }

--- a/public/apps/configuration/backend_api/client.js
+++ b/public/apps/configuration/backend_api/client.js
@@ -65,7 +65,7 @@ uiModules.get('apps/searchguard/configuration', [])
             return $http.post(url, data)
                 .then((response) => {
                     toastNotifications.addSuccess({
-                        title: `'${id}' saved.`
+                        title: `'${decodeURIComponent(id)}' saved.`
                     });
                 })
                 .catch((error) => {
@@ -84,7 +84,7 @@ uiModules.get('apps/searchguard/configuration', [])
             return $http.delete(`${AUTH_BACKEND_API_ROOT}/configuration/${resourceName}/${id}`)
                 .then((response) => {
                     toastNotifications.addSuccess({
-                        title: `'${id}' deleted.`
+                        title: `'${decodeURIComponent(id)}' deleted.`
                     });
                 })
                 .catch((error) => {

--- a/public/apps/configuration/backend_api/tenants.js
+++ b/public/apps/configuration/backend_api/tenants.js
@@ -30,13 +30,13 @@ uiModules.get('apps/searchguard/configuration', [])
             return backendAPI.get(RESOURCE, id);
         };
 
-        this.save = (actiongroupname, data) => {
+        this.save = (tenantName, data) => {
             var data = this.preSave(data);
-            return backendAPI.save(RESOURCE, actiongroupname, data);
+            return backendAPI.save(RESOURCE, encodeURIComponent(tenantname), data);
         };
 
         this.delete = (id) => {
-            return backendAPI.delete(RESOURCE, id);
+          return backendAPI.delete(RESOURCE, encodeURIComponent(id));
         };
 
         this.listAutocomplete = (names) => {

--- a/public/apps/login/get_next_url.js
+++ b/public/apps/login/get_next_url.js
@@ -17,7 +17,6 @@
 import { parse } from 'url';
 
 export function getNextUrl(currentUrl, basePath = '') {
-    currentUrl = decodeURIComponent(currentUrl);
 
     const {query, hash} = parse(currentUrl, true, true);
 

--- a/public/chrome/multitenancy/enable_multitenancy.js
+++ b/public/chrome/multitenancy/enable_multitenancy.js
@@ -86,7 +86,7 @@ export function enableMultiTenancy(Private) {
  */
 function addTenantToURL(url, originalValue = null, userRequestedTenant) {
     const tenantKey = 'sg_tenant';
-    const tenantKeyAndValue = tenantKey + '=' + userRequestedTenant;
+    const tenantKeyAndValue = tenantKey + '=' + encodeURIComponent(userRequestedTenant);
 
     if (! originalValue) {
         originalValue = url;


### PR DESCRIPTION
This PR allows for special characters in tenant names, such as `$something&_test#`.
The tenant name needs to be encoded, otherwise the *&* and *#* will break the URL. I've added the encoding to the share panel. Also, I removed the decoding from when we parse the nextUrl - it did not have the intended effect.

Fixes https://github.com/floragunncom/search-guard/issues/672.

When we backport this we need to remove the changes in tenants.js - the 6.x format handles this differently.