### PR TITLE
Add a switch to filter static and reserved table resources.

### DIFF
--- a/public/apps/configuration-react/pages/ActionGroups/ActionGroups.js
+++ b/public/apps/configuration-react/pages/ActionGroups/ActionGroups.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {
   EuiButton,
   EuiInMemoryTable,
-  EuiEmptyPrompt
+  EuiEmptyPrompt,
+  EuiSwitch
 } from '@elastic/eui';
 import { get } from 'lodash';
 import {
@@ -21,7 +22,8 @@ import {
 import { resourcesToUiResources, uiResourceToResource } from './utils';
 import { APP_PATH, ACTION_GROUPS_ACTIONS } from '../../utils/constants';
 import {
-  nameText
+  nameText,
+  systemItemsText
 } from '../../utils/i18n/common';
 import {
   actionGroupsText,
@@ -30,6 +32,7 @@ import {
   emptyActionGroupsTableMessageText,
   noActionGroupsText
 } from '../../utils/i18n/action_groups';
+import { filterReservedStaticTableResources } from '../../utils/helpers';
 
 class ActionGroups extends Component {
   constructor(props) {
@@ -39,7 +42,8 @@ class ActionGroups extends Component {
       resources: [],
       error: null,
       isLoading: true,
-      tableSelection: []
+      tableSelection: [],
+      isShowingSystemItems: true
     };
 
     this.backendService = this.props.actionGroupsService;
@@ -125,6 +129,19 @@ class ActionGroups extends Component {
     );
   }
 
+  renderToolsRight = () => {
+    const { isShowingSystemItems } = this.state;
+    return (
+      <EuiSwitch
+        label={systemItemsText}
+        checked={isShowingSystemItems}
+        onChange={() => {
+          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+        }}
+      />
+    );
+  }
+
   renderEmptyTableMessage = history => (
     <EuiEmptyPrompt
       title={<h3>{noActionGroupsText}</h3>}
@@ -142,7 +159,7 @@ class ActionGroups extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources } = this.state;
+    const { isLoading, error, resources, isShowingSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_ACTION_GROUP}?id=${name}&action=${ACTION_GROUPS_ACTIONS.UPDATE_ACTION_GROUP}`;
 
     const actions = [
@@ -221,10 +238,13 @@ class ActionGroups extends Component {
 
     const search = {
       toolsLeft: this.renderToolsLeft(),
+      toolsRight: this.renderToolsRight(),
       box: {
         incremental: true,
       }
     };
+
+    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
 
     return (
       <ContentPanel
@@ -238,7 +258,7 @@ class ActionGroups extends Component {
         ]}
       >
         <EuiInMemoryTable
-          items={resources}
+          items={tableResources}
           itemId="_id"
           error={get(error, 'message')}
           message={this.renderEmptyTableMessage(history)}

--- a/public/apps/configuration-react/pages/ActionGroups/ActionGroups.js
+++ b/public/apps/configuration-react/pages/ActionGroups/ActionGroups.js
@@ -33,24 +33,34 @@ import {
   noActionGroupsText
 } from '../../utils/i18n/action_groups';
 import { filterReservedStaticTableResources } from '../../utils/helpers';
+import { AppCacheService } from '../../services';
 
 class ActionGroups extends Component {
   constructor(props) {
     super(props);
+
+    this.backendService = this.props.actionGroupsService;
+    this.appCache = new AppCacheService();
+    const { isShowingTableSystemItems } = this.appCache.cache[APP_PATH.ACTION_GROUPS];
 
     this.state = {
       resources: [],
       error: null,
       isLoading: true,
       tableSelection: [],
-      isShowingSystemItems: true
+      isShowingTableSystemItems
     };
-
-    this.backendService = this.props.actionGroupsService;
   }
 
   componentDidMount() {
     this.fetchData();
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    const { isShowingTableSystemItems } = nextState;
+    if (isShowingTableSystemItems !== this.state.isShowingTableSystemItems) {
+      this.appCache.setCacheByPath(APP_PATH.ACTION_GROUPS, { isShowingTableSystemItems });
+    }
   }
 
   fetchData = async () => {
@@ -130,13 +140,13 @@ class ActionGroups extends Component {
   }
 
   renderToolsRight = () => {
-    const { isShowingSystemItems } = this.state;
+    const { isShowingTableSystemItems } = this.state;
     return (
       <EuiSwitch
         label={systemItemsText}
-        checked={isShowingSystemItems}
+        checked={isShowingTableSystemItems}
         onChange={() => {
-          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+          this.setState({ isShowingTableSystemItems: !isShowingTableSystemItems });
         }}
       />
     );
@@ -159,7 +169,7 @@ class ActionGroups extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources, isShowingSystemItems } = this.state;
+    const { isLoading, error, resources, isShowingTableSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_ACTION_GROUP}?id=${name}&action=${ACTION_GROUPS_ACTIONS.UPDATE_ACTION_GROUP}`;
 
     const actions = [
@@ -244,7 +254,7 @@ class ActionGroups extends Component {
       }
     };
 
-    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
+    const tableResources = filterReservedStaticTableResources(resources, isShowingTableSystemItems);
 
     return (
       <ContentPanel

--- a/public/apps/configuration-react/pages/InternalUsers/InternalUsers.js
+++ b/public/apps/configuration-react/pages/InternalUsers/InternalUsers.js
@@ -7,7 +7,8 @@ import {
   EuiText,
   EuiFlexItem,
   EuiEmptyPrompt,
-  EuiFlexGrid
+  EuiFlexGrid,
+  EuiSwitch
 } from '@elastic/eui';
 import { get } from 'lodash';
 import {
@@ -35,10 +36,12 @@ import {
 } from '../../utils/i18n/internal_users';
 import {
   nameText,
-  currentUserText
+  currentUserText,
+  systemItemsText
 } from '../../utils/i18n/common';
 import { resourcesToUiResources, uiResourceToResource } from './utils';
 import { BrowserStorageService } from '../../services';
+import { filterReservedStaticTableResources } from '../../utils/helpers';
 
 // TODO: make this component get API data by chunks (paginations)
 class InternalUsers extends Component {
@@ -49,7 +52,8 @@ class InternalUsers extends Component {
       resources: [],
       error: null,
       isLoading: true,
-      tableSelection: []
+      tableSelection: [],
+      isShowingSystemItems: false
     };
 
     this.backendService = this.props.internalUsersService;
@@ -135,6 +139,19 @@ class InternalUsers extends Component {
     );
   }
 
+  renderToolsRight = () => {
+    const { isShowingSystemItems } = this.state;
+    return (
+      <EuiSwitch
+        label={systemItemsText}
+        checked={isShowingSystemItems}
+        onChange={() => {
+          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+        }}
+      />
+    );
+  }
+
   renderEmptyTableMessage = history => (
     <EuiEmptyPrompt
       title={<h3>{noUsersText}</h3>}
@@ -173,7 +190,7 @@ class InternalUsers extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources } = this.state;
+    const { isLoading, error, resources, isShowingSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_INTERNAL_USER}?id=${name}&action=${INTERNAL_USERS_ACTIONS.UPDATE_USER}`;
 
     const actions = [
@@ -241,10 +258,13 @@ class InternalUsers extends Component {
 
     const search = {
       toolsLeft: this.renderToolsLeft(),
+      toolsRight: this.renderToolsRight(),
       box: {
         incremental: true,
       }
     };
+
+    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
 
     return (
       <ContentPanel
@@ -258,7 +278,7 @@ class InternalUsers extends Component {
         ]}
       >
         <EuiInMemoryTable
-          items={resources}
+          items={tableResources}
           itemId="_id"
           error={get(error, 'message')}
           message={this.renderEmptyTableMessage(history)}

--- a/public/apps/configuration-react/pages/Main/Main.js
+++ b/public/apps/configuration-react/pages/Main/Main.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
-import { get, differenceBy } from 'lodash';
+import { get, differenceBy, isEmpty } from 'lodash';
 import {
   EuiPage,
   EuiPageBody,
@@ -28,7 +28,7 @@ import {
   CreateRoleMapping
 } from '../';
 import { Breadcrumbs, Flyout, Callout, Modal, LoadingPage } from '../../components';
-import { APP_PATH, CALLOUTS, FLYOUTS, MODALS } from '../../utils/constants';
+import { APP_PATH, CALLOUTS, FLYOUTS, MODALS, APP_CACHE } from '../../utils/constants';
 import { checkIfLicenseValid, comboBoxOptionsToArray } from '../../utils/helpers';
 import {
   apiAccessStateForbiddenText,
@@ -37,10 +37,14 @@ import {
 } from '../../utils/i18n/main';
 import { API_ACCESS_STATE } from './utils/constants';
 import '../../less/main.less';
+import { AppCacheService } from '../../services';
 
 class Main extends Component {
   constructor(props) {
     super(props);
+
+    this.appCache = new AppCacheService();
+
     this.state = {
       purgingCache: false,
       flyout: null,
@@ -55,6 +59,7 @@ class Main extends Component {
   componentDidMount() {
     this.calloutErrorIfLicenseNotValid();
     this.checkAPIAccess();
+    if (isEmpty(this.appCache.cache)) this.appCache.cache = APP_CACHE;
   }
 
   checkAPIAccess = async () => {

--- a/public/apps/configuration-react/pages/RoleMappings/RoleMappings.js
+++ b/public/apps/configuration-react/pages/RoleMappings/RoleMappings.js
@@ -43,24 +43,34 @@ import {
   rolesText
 } from '../../utils/i18n/roles';
 import { filterReservedStaticTableResources } from '../../utils/helpers';
+import { AppCacheService } from '../../services';
 
 class RoleMappings extends Component {
   constructor(props) {
     super(props);
+
+    this.backendService = this.props.roleMappingsService;
+    this.appCache = new AppCacheService();
+    const { isShowingTableSystemItems } = this.appCache.cache[APP_PATH.ROLE_MAPPINGS];
 
     this.state = {
       resources: [],
       error: null,
       isLoading: true,
       tableSelection: [],
-      isShowingSystemItems: false
+      isShowingTableSystemItems
     };
-
-    this.backendService = this.props.roleMappingsService;
   }
 
   componentDidMount() {
     this.fetchData();
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    const { isShowingTableSystemItems } = nextState;
+    if (isShowingTableSystemItems !== this.state.isShowingTableSystemItems) {
+      this.appCache.setCacheByPath(APP_PATH.ROLE_MAPPINGS, { isShowingTableSystemItems });
+    }
   }
 
   fetchData = async () => {
@@ -144,13 +154,13 @@ class RoleMappings extends Component {
   }
 
   renderToolsRight = () => {
-    const { isShowingSystemItems } = this.state;
+    const { isShowingTableSystemItems } = this.state;
     return (
       <EuiSwitch
         label={systemItemsText}
-        checked={isShowingSystemItems}
+        checked={isShowingTableSystemItems}
         onChange={() => {
-          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+          this.setState({ isShowingTableSystemItems: !isShowingTableSystemItems });
         }}
       />
     );
@@ -173,7 +183,7 @@ class RoleMappings extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources, isShowingSystemItems } = this.state;
+    const { isLoading, error, resources, isShowingTableSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_ROLE_MAPPING}?id=${name}&action=${ROLE_MAPPINGS_ACTIONS.UPDATE_ROLE_MAPPING}`;
 
     const actions = [
@@ -286,7 +296,7 @@ class RoleMappings extends Component {
       }
     };
 
-    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
+    const tableResources = filterReservedStaticTableResources(resources, isShowingTableSystemItems);
 
     return (
       <ContentPanel

--- a/public/apps/configuration-react/pages/RoleMappings/RoleMappings.js
+++ b/public/apps/configuration-react/pages/RoleMappings/RoleMappings.js
@@ -5,7 +5,8 @@ import {
   EuiInMemoryTable,
   EuiEmptyPrompt,
   EuiSpacer,
-  EuiCallOut
+  EuiCallOut,
+  EuiSwitch
 } from '@elastic/eui';
 import { get } from 'lodash';
 import {
@@ -26,7 +27,8 @@ import {
 } from './utils';
 import { APP_PATH, ROLE_MAPPINGS_ACTIONS } from '../../utils/constants';
 import {
-  nameText
+  nameText,
+  systemItemsText
 } from '../../utils/i18n/common';
 import {
   roleMappingsText,
@@ -40,6 +42,7 @@ import {
   hostsText,
   rolesText
 } from '../../utils/i18n/roles';
+import { filterReservedStaticTableResources } from '../../utils/helpers';
 
 class RoleMappings extends Component {
   constructor(props) {
@@ -49,7 +52,8 @@ class RoleMappings extends Component {
       resources: [],
       error: null,
       isLoading: true,
-      tableSelection: []
+      tableSelection: [],
+      isShowingSystemItems: false
     };
 
     this.backendService = this.props.roleMappingsService;
@@ -139,6 +143,19 @@ class RoleMappings extends Component {
     );
   }
 
+  renderToolsRight = () => {
+    const { isShowingSystemItems } = this.state;
+    return (
+      <EuiSwitch
+        label={systemItemsText}
+        checked={isShowingSystemItems}
+        onChange={() => {
+          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+        }}
+      />
+    );
+  }
+
   renderEmptyTableMessage = history => (
     <EuiEmptyPrompt
       title={<h3>{noRoleMappingsText}</h3>}
@@ -156,7 +173,7 @@ class RoleMappings extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources } = this.state;
+    const { isLoading, error, resources, isShowingSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_ROLE_MAPPING}?id=${name}&action=${ROLE_MAPPINGS_ACTIONS.UPDATE_ROLE_MAPPING}`;
 
     const actions = [
@@ -263,10 +280,13 @@ class RoleMappings extends Component {
 
     const search = {
       toolsLeft: this.renderToolsLeft(),
+      toolsRight: this.renderToolsRight(),
       box: {
         incremental: true,
       }
     };
+
+    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
 
     return (
       <ContentPanel
@@ -280,7 +300,7 @@ class RoleMappings extends Component {
         ]}
       >
         <EuiInMemoryTable
-          items={resources}
+          items={tableResources}
           itemId="_id"
           error={get(error, 'message')}
           message={this.renderEmptyTableMessage(history)}

--- a/public/apps/configuration-react/pages/Roles/Roles.js
+++ b/public/apps/configuration-react/pages/Roles/Roles.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {
   EuiButton,
   EuiInMemoryTable,
-  EuiEmptyPrompt
+  EuiEmptyPrompt,
+  EuiSwitch
 } from '@elastic/eui';
 import { get } from 'lodash';
 import {
@@ -21,7 +22,8 @@ import {
 import { resourcesToUiResources, uiResourceToResource } from './utils';
 import { APP_PATH, ROLES_ACTIONS } from '../../utils/constants';
 import {
-  nameText
+  nameText,
+  systemItemsText
 } from '../../utils/i18n/common';
 import {
   rolesText,
@@ -31,6 +33,7 @@ import {
   indexPatternsText,
   tenantPatternsText
 } from '../../utils/i18n/roles';
+import { filterReservedStaticTableResources } from '../../utils/helpers';
 
 class Roles extends Component {
   constructor(props) {
@@ -40,7 +43,8 @@ class Roles extends Component {
       resources: [],
       error: null,
       isLoading: true,
-      tableSelection: []
+      tableSelection: [],
+      isShowingSystemItems: false
     };
 
     this.backendService = this.props.rolesService;
@@ -125,6 +129,19 @@ class Roles extends Component {
     );
   }
 
+  renderToolsRight = () => {
+    const { isShowingSystemItems } = this.state;
+    return (
+      <EuiSwitch
+        label={systemItemsText}
+        checked={isShowingSystemItems}
+        onChange={() => {
+          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+        }}
+      />
+    );
+  }
+
   renderEmptyTableMessage = history => (
     <EuiEmptyPrompt
       title={<h3>{rolesText}</h3>}
@@ -142,7 +159,7 @@ class Roles extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources } = this.state;
+    const { isLoading, error, resources, isShowingSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_ROLE}?id=${name}&action=${ROLES_ACTIONS.UPDATE_ROLE}`;
 
     const actions = [
@@ -233,10 +250,13 @@ class Roles extends Component {
 
     const search = {
       toolsLeft: this.renderToolsLeft(),
+      toolsRight: this.renderToolsRight(),
       box: {
         incremental: true,
       }
     };
+
+    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
 
     return (
       <ContentPanel
@@ -250,7 +270,7 @@ class Roles extends Component {
         ]}
       >
         <EuiInMemoryTable
-          items={resources}
+          items={tableResources}
           itemId="_id"
           error={get(error, 'message')}
           message={this.renderEmptyTableMessage(history)}

--- a/public/apps/configuration-react/pages/Roles/Roles.js
+++ b/public/apps/configuration-react/pages/Roles/Roles.js
@@ -34,24 +34,34 @@ import {
   tenantPatternsText
 } from '../../utils/i18n/roles';
 import { filterReservedStaticTableResources } from '../../utils/helpers';
+import { AppCacheService } from '../../services';
 
 class Roles extends Component {
   constructor(props) {
     super(props);
+
+    this.backendService = this.props.rolesService;
+    this.appCache = new AppCacheService();
+    const { isShowingTableSystemItems } = this.appCache.cache[APP_PATH.ROLES];
 
     this.state = {
       resources: [],
       error: null,
       isLoading: true,
       tableSelection: [],
-      isShowingSystemItems: false
+      isShowingTableSystemItems
     };
-
-    this.backendService = this.props.rolesService;
   }
 
   componentDidMount() {
     this.fetchData();
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    const { isShowingTableSystemItems } = nextState;
+    if (isShowingTableSystemItems !== this.state.isShowingTableSystemItems) {
+      this.appCache.setCacheByPath(APP_PATH.ROLES, { isShowingTableSystemItems });
+    }
   }
 
   fetchData = async () => {
@@ -130,13 +140,13 @@ class Roles extends Component {
   }
 
   renderToolsRight = () => {
-    const { isShowingSystemItems } = this.state;
+    const { isShowingTableSystemItems } = this.state;
     return (
       <EuiSwitch
         label={systemItemsText}
-        checked={isShowingSystemItems}
+        checked={isShowingTableSystemItems}
         onChange={() => {
-          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+          this.setState({ isShowingTableSystemItems: !isShowingTableSystemItems });
         }}
       />
     );
@@ -159,7 +169,7 @@ class Roles extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources, isShowingSystemItems } = this.state;
+    const { isLoading, error, resources, isShowingTableSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_ROLE}?id=${name}&action=${ROLES_ACTIONS.UPDATE_ROLE}`;
 
     const actions = [
@@ -256,7 +266,7 @@ class Roles extends Component {
       }
     };
 
-    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
+    const tableResources = filterReservedStaticTableResources(resources, isShowingTableSystemItems);
 
     return (
       <ContentPanel

--- a/public/apps/configuration-react/pages/Tenants/Tenants.js
+++ b/public/apps/configuration-react/pages/Tenants/Tenants.js
@@ -33,24 +33,34 @@ import {
   noTenantsText
 } from '../../utils/i18n/tenants';
 import { filterReservedStaticTableResources } from '../../utils/helpers';
+import { AppCacheService } from '../../services';
 
 class Tenants extends Component {
   constructor(props) {
     super(props);
+
+    this.backendService = this.props.tenantsService;
+    this.appCache = new AppCacheService();
+    const { isShowingTableSystemItems } = this.appCache.cache[APP_PATH.TENANTS];
 
     this.state = {
       resources: [],
       error: null,
       isLoading: true,
       tableSelection: [],
-      isShowingSystemItems: false
+      isShowingTableSystemItems
     };
-
-    this.backendService = this.props.tenantsService;
   }
 
   componentDidMount() {
     this.fetchData();
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    const { isShowingTableSystemItems } = nextState;
+    if (isShowingTableSystemItems !== this.state.isShowingTableSystemItems) {
+      this.appCache.setCacheByPath(APP_PATH.TENANTS, { isShowingTableSystemItems });
+    }
   }
 
   fetchData = async () => {
@@ -129,13 +139,13 @@ class Tenants extends Component {
   }
 
   renderToolsRight = () => {
-    const { isShowingSystemItems } = this.state;
+    const { isShowingTableSystemItems } = this.state;
     return (
       <EuiSwitch
         label={systemItemsText}
-        checked={isShowingSystemItems}
+        checked={isShowingTableSystemItems}
         onChange={() => {
-          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+          this.setState({ isShowingTableSystemItems: !isShowingTableSystemItems });
         }}
       />
     );
@@ -158,7 +168,7 @@ class Tenants extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources, isShowingSystemItems } = this.state;
+    const { isLoading, error, resources, isShowingTableSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_TENANT}?id=${name}&action=${TENANTS_ACTIONS.UPDATE_TENANT}`;
 
     const actions = [
@@ -231,7 +241,7 @@ class Tenants extends Component {
       }
     };
 
-    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
+    const tableResources = filterReservedStaticTableResources(resources, isShowingTableSystemItems);
 
     return (
       <ContentPanel

--- a/public/apps/configuration-react/pages/Tenants/Tenants.js
+++ b/public/apps/configuration-react/pages/Tenants/Tenants.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {
   EuiButton,
   EuiInMemoryTable,
-  EuiEmptyPrompt
+  EuiEmptyPrompt,
+  EuiSwitch
 } from '@elastic/eui';
 import { get } from 'lodash';
 import {
@@ -22,7 +23,8 @@ import { resourcesToUiResources, uiResourceToResource } from './utils';
 import { APP_PATH, TENANTS_ACTIONS } from '../../utils/constants';
 import {
   nameText,
-  descriptionText
+  descriptionText,
+  systemItemsText
 } from '../../utils/i18n/common';
 import {
   tenantsText,
@@ -30,6 +32,7 @@ import {
   emptyTenantsTableMessageText,
   noTenantsText
 } from '../../utils/i18n/tenants';
+import { filterReservedStaticTableResources } from '../../utils/helpers';
 
 class Tenants extends Component {
   constructor(props) {
@@ -39,7 +42,8 @@ class Tenants extends Component {
       resources: [],
       error: null,
       isLoading: true,
-      tableSelection: []
+      tableSelection: [],
+      isShowingSystemItems: false
     };
 
     this.backendService = this.props.tenantsService;
@@ -124,6 +128,19 @@ class Tenants extends Component {
     );
   }
 
+  renderToolsRight = () => {
+    const { isShowingSystemItems } = this.state;
+    return (
+      <EuiSwitch
+        label={systemItemsText}
+        checked={isShowingSystemItems}
+        onChange={() => {
+          this.setState({ isShowingSystemItems: !isShowingSystemItems });
+        }}
+      />
+    );
+  }
+
   renderEmptyTableMessage = history => (
     <EuiEmptyPrompt
       title={<h3>{noTenantsText}</h3>}
@@ -141,7 +158,7 @@ class Tenants extends Component {
 
   render() {
     const { history } = this.props;
-    const { isLoading, error, resources } = this.state;
+    const { isLoading, error, resources, isShowingSystemItems } = this.state;
     const getResourceEditUri = name => `${APP_PATH.CREATE_TENANT}?id=${name}&action=${TENANTS_ACTIONS.UPDATE_TENANT}`;
 
     const actions = [
@@ -208,10 +225,13 @@ class Tenants extends Component {
 
     const search = {
       toolsLeft: this.renderToolsLeft(),
+      toolsRight: this.renderToolsRight(),
       box: {
         incremental: true,
       }
     };
+
+    const tableResources = filterReservedStaticTableResources(resources, isShowingSystemItems);
 
     return (
       <ContentPanel
@@ -225,7 +245,7 @@ class Tenants extends Component {
         ]}
       >
         <EuiInMemoryTable
-          items={resources}
+          items={tableResources}
           itemId="_id"
           error={get(error, 'message')}
           message={this.renderEmptyTableMessage(history)}

--- a/public/apps/configuration-react/services/AppCacheService.js
+++ b/public/apps/configuration-react/services/AppCacheService.js
@@ -1,0 +1,17 @@
+import { APP_CACHE_NAME } from '../utils/constants';
+
+export default class AppCacheService {
+  get cache() {
+    return JSON.parse(localStorage.getItem(APP_CACHE_NAME), '{}');
+  }
+
+  set cache(cache = {}) {
+    localStorage.setItem(APP_CACHE_NAME, JSON.stringify(cache));
+  }
+
+  setCacheByPath(appPath, cache = {}) {
+    localStorage.setItem(APP_CACHE_NAME, JSON.stringify({
+      ...this.cache, [appPath]: { ...this.cache[appPath], ...cache }
+    }));
+  }
+}

--- a/public/apps/configuration-react/services/index.js
+++ b/public/apps/configuration-react/services/index.js
@@ -1,2 +1,3 @@
 export { default as SystemService } from './SystemService';
 export { default as BrowserStorageService } from './BrowserStorageService';
+export { default as AppCacheService } from './AppCacheService';

--- a/public/apps/configuration-react/utils/constants.js
+++ b/public/apps/configuration-react/utils/constants.js
@@ -72,3 +72,28 @@ export { default as INDEX_PERMISSIONS } from '../../configuration/permissions/in
 export { default as CLUSTER_PERMISSIONS } from '../../configuration/permissions/clusterpermissions';
 
 export const FIELDS_TO_OMIT_BEFORE_SAVE = ['reserved', 'static', 'hidden'];
+
+export const APP_CACHE_NAME = 'app_cache';
+const APP_CACHE_COMMON = {
+  isShowingTableSystemItems: false
+};
+export const APP_CACHE = {
+  [APP_PATH.ROLE_MAPPINGS]: {
+    ...APP_CACHE_COMMON
+  },
+  [APP_PATH.INTERNAL_USERS]: {
+    ...APP_CACHE_COMMON
+  },
+  [APP_PATH.ROLE_MAPPINGS]: {
+    ...APP_CACHE_COMMON
+  },
+  [APP_PATH.ROLES]: {
+    ...APP_CACHE_COMMON
+  },
+  [APP_PATH.ACTION_GROUPS]: {
+    ...APP_CACHE_COMMON
+  },
+  [APP_PATH.TENANTS]: {
+    ...APP_CACHE_COMMON
+  },
+};

--- a/public/apps/configuration-react/utils/helpers/helpers.test.js
+++ b/public/apps/configuration-react/utils/helpers/helpers.test.js
@@ -6,8 +6,9 @@ import {
   arrayToComboBoxOptions,
   comboBoxOptionsToArray,
   attributesToUiAttributes,
-  uiAttributesToAttributes
-} from './helpers';
+  uiAttributesToAttributes,
+  filterReservedStaticTableResources
+} from './index';
 
 describe('common helpers', () => {
   test('can build UI backend roles from internal users', () => {
@@ -99,5 +100,18 @@ describe('common helpers', () => {
     ];
 
     expect(uiAttributesToAttributes(uiAttributes)).toEqual(attributes);
+  });
+
+  test('can filter reserved and static resources', () => {
+    const resources = [
+      { a: 1, static: true },
+      { b: 2, reserved: true },
+      { c: 3 }
+    ];
+
+    let isShowingSystemItems = false;
+    expect(filterReservedStaticTableResources(resources, isShowingSystemItems)).toEqual([{ c: 3 }]);
+    isShowingSystemItems = true;
+    expect(filterReservedStaticTableResources(resources, isShowingSystemItems)).toEqual(resources);
   });
 });

--- a/public/apps/configuration-react/utils/helpers/index.js
+++ b/public/apps/configuration-react/utils/helpers/index.js
@@ -1,6 +1,6 @@
 import BrowserStorageService from '../../services/BrowserStorageService';
 import { INDEX_PERMISSIONS, CLUSTER_PERMISSIONS } from '../constants';
-import { get, reduce, sortBy, uniqBy, forEach, map } from 'lodash';
+import { get, reduce, sortBy, uniqBy, forEach, map, filter } from 'lodash';
 
 export { default as sideNavItem } from './sideNavItem';
 
@@ -89,3 +89,7 @@ export const internalUsersToUiBackendRoles = (internalUsers = {}) => {
 
 export const getAllUiClusterPermissions = () => map(CLUSTER_PERMISSIONS, ({ name }) => ({ label: name }));
 export const getAllUiIndexPermissions = () => map(INDEX_PERMISSIONS, ({ name }) => ({ label: name }));
+
+export const filterReservedStaticTableResources = (resources = [], isShowingSystemItems = false) => !isShowingSystemItems
+  ? filter(resources, resource => !resource.reserved && !resource.static)
+  : resources;

--- a/public/apps/configuration-react/utils/i18n/common.js
+++ b/public/apps/configuration-react/utils/i18n/common.js
@@ -42,3 +42,4 @@ export const includeText = (<EuiI18n token="sg.common.include.text" default="Inc
 export const excludeText = (<EuiI18n token="sg.common.exclude.text" default="Exclude" />);
 export const jsonIsInvalidText = (<EuiI18n token="sg.common.jsonIsInvalid.text" default="JSON is invalid" />);
 export const jsonMustNotBeEmptyText = (<EuiI18n token="sg.common.jsonMustNotBeEmpty.text" default="JSON must not be empty" />);
+export const systemItemsText = (<EuiI18n token="sg.common.systemItems.text" default="System Items" />);

--- a/public/apps/configuration-react/utils/i18n/role_mappings.js
+++ b/public/apps/configuration-react/utils/i18n/role_mappings.js
@@ -16,8 +16,8 @@ export const emptyRoleMappingsTableMessageText = (
 );
 
 export const roleHelpText = (
-  <EuiI18n token="role_mappings.roleHelp.text" default="If you neead a new role," />
+  <EuiI18n token="sg.role_mappings.roleHelp.text" default="If you neead a new role," />
 );
 export const noCorrespondingRoleText = (
-  <EuiI18n token="role_mappings.noCorrespondingRole.text" default="No corresponding role" />
+  <EuiI18n token="sg.role_mappings.noCorrespondingRole.text" default="No corresponding role" />
 );


### PR DESCRIPTION
This closes https://floragunn.atlassian.net/browse/ITT-2205

To-do:
- [x] add switch
- [x] cache user preference

To check this PR
1. Visit all the following pages: Internal Users, Role Mappings, Roles, Action Groups and Tenants
2. See a switch with label **System Items** next to the table search bar
3. Reserved and static resources shouldn't be visible in the table
4. Trigger the switch and see the hidden resources

ATTENTION! The switch logic is reversed for Action Groups, look the issue for details.

Screenshots
![Screenshot 2019-06-25 at 12 46 01](https://user-images.githubusercontent.com/5389745/60092687-eca1a700-9747-11e9-801c-5c73455154c0.png)
![Screenshot 2019-06-25 at 12 46 06](https://user-images.githubusercontent.com/5389745/60092689-eca1a700-9747-11e9-9acf-77534af74436.png)
 