### PR TITLE
Allow adding custom values to Index Pattern Single Permissions ComboBox

### DIFF
--- a/public/apps/configuration-react/pages/CreateRole/components/ClusterPermissions/ClusterPermissions.js
+++ b/public/apps/configuration-react/pages/CreateRole/components/ClusterPermissions/ClusterPermissions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormikComboBox, FormikSwitch } from '../../../../components';
 import { actionGroupsText, singlePermissionsText } from '../../../../utils/i18n/action_groups';
 import { advancedText } from '../../../../utils/i18n/common';
-import { validClusterSinglePermissionOption } from '../../../../utils/validation';
+import { validSinglePermissionOption } from '../../../../utils/validation';
 
 const ClusterPermissions = ({
   allActionGroups,
@@ -46,7 +46,7 @@ const ClusterPermissions = ({
           options: allSinglePermissions,
           isClearable: true,
           onBlur: onComboBoxOnBlur,
-          onCreateOption: onComboBoxCreateOption(validClusterSinglePermissionOption),
+          onCreateOption: onComboBoxCreateOption(validSinglePermissionOption),
           onChange: onComboBoxChange()
         }}
       />

--- a/public/apps/configuration-react/pages/CreateRole/components/IndexPermissions/IndexPatterns.js
+++ b/public/apps/configuration-react/pages/CreateRole/components/IndexPermissions/IndexPatterns.js
@@ -27,7 +27,12 @@ import {
   TitleSecondary
 } from '../../../../components';
 import { comboBoxOptionsToArray } from '../../../../utils/helpers';
-import { isInvalid, hasError, validateESDLSQuery } from '../../../../utils/validation';
+import {
+  isInvalid,
+  hasError,
+  validateESDLSQuery,
+  validIndicesSinglePermissionOption
+} from '../../../../utils/validation';
 import FieldLevelSecurity from './FieldLevelSecurity';
 
 const indexPatternNames = (indexPatterns = []) => comboBoxOptionsToArray(indexPatterns).join(', ');
@@ -122,6 +127,7 @@ const IndexPatterns = ({
                 options: allSinglePermissions,
                 isClearable: true,
                 onBlur: onComboBoxOnBlur,
+                onCreateOption: onComboBoxCreateOption(validIndicesSinglePermissionOption),
                 onChange: onComboBoxChange()
               }}
             />

--- a/public/apps/configuration-react/utils/validation.js
+++ b/public/apps/configuration-react/utils/validation.js
@@ -81,4 +81,5 @@ export const validateEmptyComboBox = value => {
 };
 
 export const validClusterSinglePermissionOption = label => (/^cluster:[\w\*].*/).test(label);
+export const validIndicesSinglePermissionOption = label => (/^indices:[\w\*].*/).test(label);
 export const validSinglePermissionOption = label => (/^((cluster)|(indices)):[\w\*].*/).test(label);

--- a/public/apps/configuration-react/utils/validation.test.js
+++ b/public/apps/configuration-react/utils/validation.test.js
@@ -3,7 +3,8 @@ import {
   validatePassword,
   validateEmptyComboBox,
   validClusterSinglePermissionOption,
-  validSinglePermissionOption
+  validSinglePermissionOption,
+  validIndicesSinglePermissionOption
 } from './validation';
 import {
   jsonIsInvalidText,
@@ -125,16 +126,22 @@ describe('validation', () => {
   });
 
   describe('validate single permissions', () => {
-    test('can validate cluster permission', () => {
+    test('can validate cluster and indices permission', () => {
       expect(validClusterSinglePermissionOption('cluster:*')).toEqual(true);
       expect(validClusterSinglePermissionOption('cluster:a')).toEqual(true);
       expect(validClusterSinglePermissionOption('cluster:a/b/c')).toEqual(true);
+      expect(validIndicesSinglePermissionOption('indices:*')).toEqual(true);
+      expect(validIndicesSinglePermissionOption('indices:a')).toEqual(true);
+      expect(validIndicesSinglePermissionOption('indices:a/b/c')).toEqual(true);
     });
 
     test('fail to validate cluster permission', () => {
       expect(validClusterSinglePermissionOption('cluster:')).toEqual(false);
       expect(validClusterSinglePermissionOption('cat')).toEqual(false);
       expect(validClusterSinglePermissionOption('indices:a/b/c')).toEqual(false);
+      expect(validIndicesSinglePermissionOption('indices:')).toEqual(false);
+      expect(validIndicesSinglePermissionOption('cat')).toEqual(false);
+      expect(validIndicesSinglePermissionOption('cluster:a/b/c')).toEqual(false);
     });
 
     test('can validate single permission', () => {


### PR DESCRIPTION
This closes https://floragunn.atlassian.net/browse/ITT-2264

**REBASE THIS BEFORE MERGE!**

To check this PR 
1. Go to Create Role
2. Go to Index Permissions tab
3. Trigger Advanced switch
4. Add `indices:data/read*` to Single Permissions ComboBox
5. See the value accepted
6. Go to Cluster Permissions tab
7. Trigger Advanced switch
8. Add `cluster:a` to Single Permissions ComboBox
9. Add `indices:a`
10. See both options accepted
