### PR TITLE
Register React app for the left navbar if user has API access and hide the app when there is no access.

### DIFF
--- a/public/chrome/configuration/enable_configuration.js
+++ b/public/chrome/configuration/enable_configuration.js
@@ -153,8 +153,20 @@ export function enableConfiguration($http, $window, systemstate) {
                         category: FeatureCatalogueCategory.ADMIN
                     };
                 });
+                FeatureCatalogueRegistryProvider.register(() => {
+                    return {
+                        id: 'searchguard-configuration-react',
+                        title: 'Search Guard Configuration',
+                        description: 'Configure users, roles and permissions for Search Guard.',
+                        icon: 'securityApp',
+                        path: '/app/searchguard-configuration-react',
+                        showOnHomePage: true,
+                        category: FeatureCatalogueCategory.ADMIN
+                    };
+                });
             } else {
                 chrome.getNavLinkById("searchguard-configuration").hidden = true;
+                chrome.getNavLinkById("searchguard-configuration-react").hidden = true;
             }
         });
     });


### PR DESCRIPTION
This closes https://floragunn.atlassian.net/browse/ITT-2248

To check this PR
1. Add a user with no API access

1.1. Add user to sg_internal_users.yml
```
hr_employee:
  hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
  backend_roles:
  - "kibanauser"
  attributes:
    attribute1: "value1"
    attribute2: "value2"
    attribute3: "value3"
```
1.2. Add role mapping to sg_roles_mapping.yml
```
sg_human_resources:
  backend_roles:
  - "hr"
  - "jwt_hr"
  users:
  - "hr_employee"
```
1.3. Add role to sg_roles.yml
```
sg_human_resources:
  cluster_permissions:
    - SGS_CLUSTER_COMPOSITE_OPS
  index_permissions:
    - index_patterns:
      - 'humanresources'
      allowed_actions:
        - SGS_UNLIMITED
  tenant_permissions:
    - tenant_patterns:
      - human_resources
      allowed_actions:
        - SGS_KIBANA_ALL_WRITE
    - tenant_patterns:
      - performance_data
      allowed_actions:
        - SGS_KIBANA_ALL_WRITE
    - tenant_patterns:
      - business_intelligence
      allowed_actions:
        - SGS_KIBANA_ALL_READ
    - tenant_patterns:
      - management
      allowed_actions:
        - SGS_KIBANA_ALL_WRITE
```

1.4 Reload searchguard
```
#!/bin/bash

ESFOLDER="elasticsearch-7.1.0"

"/Users/sergiibondarenko/Development/kibana/dist/$ESFOLDER/plugins/search-guard-7/tools/sgadmin.sh" -cd "/Users/sergiibondarenko/Development/kibana/dist/$ESFOLDER/plugins/search-guard-7/sgconfig" -icl -key "/Users/sergiibondarenko/Development/kibana/dist/$ESFOLDER/config/kirk-key.pem" -cert "/Users/sergiibondarenko/Development/kibana/dist/$ESFOLDER/config/kirk.pem" -cacert "/Users/sergiibondarenko/Development/kibana/dist/$ESFOLDER/config/root-ca.pem" -nhnv
``` 

2. Login to Kibana with user **hr_employee**, password **admin**
3. See no Search Guard icon on the left navbar