### PR TITLE
ITT-2220 - Remove action group type "kibana" for now

### DIFF
--- a/public/apps/configuration-react/pages/CreateActionGroup/utils/constants.js
+++ b/public/apps/configuration-react/pages/CreateActionGroup/utils/constants.js
@@ -1,7 +1,6 @@
 export const TYPES = [
-  { value: 'cluster', text: 'cluster' },
-  { value: 'index', text: 'index' },
-  { value: 'kibana', text: 'kibana' }
+  { value: 'cluster', text: 'Cluster' },
+  { value: 'index', text: 'Index' }
 ];
 
 export const DEFAULT_ACTION_GROUP = {


### PR DESCRIPTION
This PR removes the "kibana" action type. Also, Cluster and Index are now capitalised in the dropdown.