### PR TITLE
ITT-2350 - Warn when alwaysPresentCertificate is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,8 +500,12 @@ export default function (kibana) {
 
 
             // Using an admin certificate may lead to unintended consequences
-            if ((typeof legacyEsConfig.ssl.certificate !== 'undefined' && typeof legacyEsConfig.ssl.certificate !== false) && config.get('searchguard.allow_client_certificates') !== true) {
-                this.status.red("'elasticsearch.ssl.certificate' can not be used without setting 'searchguard.allow_client_certificates' to 'true' in kibana.yml. Please refer to the documentation for more information about the implications of doing so.");
+            if (typeof legacyEsConfig.ssl.certificate !== 'undefined' && typeof legacyEsConfig.ssl.certificate !== false) {
+                if (config.get('searchguard.allow_client_certificates') !== true) {
+                    this.status.red("'elasticsearch.ssl.certificate' can not be used without setting 'searchguard.allow_client_certificates' to 'true' in kibana.yml. Please refer to the documentation for more information about the implications of doing so.");
+                } else if (legacyEsConfig.ssl.alwaysPresentCertificate === true) {
+                    this.status.red("'elasticsearch.ssl.alwaysPresentCertificate' may lead to requests being executed as the user attached to the certificate configured in 'elasticsearch.ssl.certificate'.");
+                }
             }
         }
     });


### PR DESCRIPTION
This PR shows a warning when having es configured to use a ssl certificate and to always present the certificate.